### PR TITLE
Limit the max memory the container can use when compiling

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -219,7 +219,7 @@ pipeline {
                 def bundle_image = docker.image(bundleImage(recipe_label))
                 docker.withRegistry(docker_registry_uri, docker_credentials) { bundle_image.pull() }
 
-                bundle_image.inside("-v $HOME/tailor/ccache:/ccache") {
+                bundle_image.inside("-v $HOME/tailor/ccache:/ccache --memory=15500m") {
                   unstash(name: srcStash(params.release_label))
                   unstash(name: debianStash(recipe_label))
                   sh("""


### PR DESCRIPTION
As previously discussed, the `Cannot contact Linux` issue seem related to a memory issue when compiling ros bridge. When that happens, even if the instance is running on AWS, I couldn't connect to it via ssh.

This will limit the memory allowed to the container so we can at least connect to the host instance and debug.