### PR TITLE
Remove parent setup file

### DIFF
--- a/tailor_distro/debian_templates/rules.j2
+++ b/tailor_distro/debian_templates/rules.j2
@@ -4,12 +4,11 @@
 	dh $@
 
 export PYTHONUNBUFFERED=1
-export LOCUS_VERSION={{ release_label}}-{{ debian_version }}
+export LOCUS_VERSION={{ release_label }}-{{ debian_version }}
 export CCACHE_BASEDIR=$(CURDIR)
 
 SHELL=bash
 INSTALL_DIR=debian/tmp/opt/{{ organization }}/{{ release_label }}/{{ flavour }}
-SETUP_FILE=$(INSTALL_DIR)/setup.bash
 
 # Do this oneshot as part of override_dh_auto_install
 override_dh_auto_clean:
@@ -19,7 +18,6 @@ override_dh_auto_test:
 
 override_dh_auto_install:
 	mkdir -p $(INSTALL_DIR)
-	touch $(SETUP_FILE)
 
 {% for distro_name, distro_options in distributions.items() if distro_options['root_packages'] is defined %}
 	{% for vendor_environment in vendor_environments | default([])  %}
@@ -48,8 +46,6 @@ override_dh_auto_install:
 		--catkin-cmake-args \
 			-DCATKIN_SKIP_TESTING=1 \
 		--merge-install
-
-	echo "source $(INSTALL_DIR)/{{ distro_name }}/local_setup.bash" >> $(SETUP_FILE)
 
 	{% if distro_options['compat_catkin_tools'] | default(False) == True %}
 		# Workaround colcon not creating env.sh https://github.com/colcon/colcon-ros/issues/16


### PR DESCRIPTION
At one point this was useful, but now it's just confusing.

Colcon chains workspaces internally (ros2/setup.bash automatically sources ros1/setup.bash).