### PR TITLE
Add cache invalidation after pushing the packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -294,6 +294,11 @@ pipeline {
                         "--keys /gpg/*.key --distribution $distribution " +
                         "${params.days_to_keep != 'null' ? '--days-to-keep ' + params.days_to_keep : ''} " +
                         "${params.num_to_keep != 'null' ? '--num-to-keep ' + params.num_to_keep : ''}")
+
+                    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'tailor_aws']]) {
+                        // TODO(gservin): Don't hardcode Cloudfront ID
+                        cfInvalidate(distribution:'E3MLX3ENEGCWZZ', paths:['/*'])
+                    }
                   }
                 }
               } finally {


### PR DESCRIPTION
This is a quick fox for the invalidating the Cloudfront cache. The main issue with this is that the id of the  distribution is hard-coded, using the AWS plugin we can read the id from the Cloudformation stack, but then we'll have to hard-code the name of the stack, so I decided for the simple solution for now.

I also have in place a Cloudformation change to our current template that will add the invalidation via a Lambda function, but still need some work.

Ran a test and confirmed it created the invalidation here: 
http://tailor.locusbots.io/blue/organizations/jenkins/ci%2Ftailor-distro/detail/RST-1600_Add-invalidation-for-cloudfront/3/pipeline