### PR TITLE
Include buildtool dependencies in builds

### DIFF
--- a/tailor_distro/debian_templates/Dockerfile.j2
+++ b/tailor_distro/debian_templates/Dockerfile.j2
@@ -37,40 +37,17 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 142D5F1683E1528B &&
 
 # Install colcon build tool
 RUN apt-get update && apt-get install --no-install-recommends -y \
+{% if os_version == 'xenial' %}
     python3-dev \
     python3-pip \
-    python3-setuptools \
-    python3-wheel \
-    git
+{% endif %}
+    python3-colcon-common-extensions
 
+{% if os_version == 'xenial' %}
+# xenial needs a newer setuptools for colcon to work
 RUN pip3 install -U \
-    pip \
     setuptools
-
-RUN pip3 install \
-    catkin-pkg==0.4.8 \
-    colcon-argcomplete==0.2.1 \
-    colcon-bash==0.3.1 \
-    colcon-cmake==0.2.3 \
-    colcon-common-extensions==0.2.0 \
-    colcon-core==0.3.9 \
-    colcon-defaults==0.2.0 \
-    colcon-devtools==0.2.1 \
-    colcon-library-path==0.2.0 \
-    colcon-metadata==0.2.0 \
-    colcon-notification==0.2.5 \
-    colcon-output==0.2.2 \
-    colcon-package-information==0.2.1 \
-    colcon-package-selection==0.2.0 \
-    colcon-parallel-executor==0.2.2 \
-    colcon-pkg-config==0.1.0 \
-    colcon-powershell==0.3.3 \
-    colcon-python-setup-py==0.2.0 \
-    colcon-recursive-crawl==0.2.0 \
-    # colcon-ros==0.3.3 \
-    git+https://github.com/paulbovbel/colcon-ros.git@catkin-env-hooks \
-    colcon-test-result==0.3.0 \
-    colcon-zsh==0.3.1
+{% endif %}
 
 # Install build and run dependencies
 # TODO(pbovbel) install contrainted versions of packages rather than using 'regex_replace'

--- a/tailor_distro/debian_templates/rules.j2
+++ b/tailor_distro/debian_templates/rules.j2
@@ -45,8 +45,8 @@ override_dh_auto_install:
 			-DBUILD_TESTING=OFF \
 		--catkin-cmake-args \
 			-DCATKIN_SKIP_TESTING=1 \
-		--catkin-skip-building-tests \
-		--merge-install
+		--merge-install \
+		--catkin-skip-building-tests
 
 	{% if distro_options['compat_catkin_tools'] | default(False) == True %}
 		# Workaround colcon not creating env.sh https://github.com/colcon/colcon-ros/issues/16

--- a/tailor_distro/generate_bundle_templates.py
+++ b/tailor_distro/generate_bundle_templates.py
@@ -29,9 +29,8 @@ def get_debian_depends(package: Package):
 def get_debian_build_depends(package: Package):
     return set(
         package.build_depends +
-        # Unneeded if we don't build tests or docs
-        # package.doc_depends +
-        # package.test_depends +
+        package.doc_depends +
+        package.test_depends +
         package.buildtool_depends +
         package.build_export_depends +
         package.buildtool_export_depends
@@ -120,7 +119,9 @@ def get_packages_in_workspace(workspace: pathlib.Path, root_packages: Iterable[s
         try:
             package_description = packages[package]
             filtered.add(package)
+            print(package)
         except Exception:
+            print(package)
             continue
 
         for dependency in get_debian_depends(package_description) | get_debian_build_depends(package_description):


### PR DESCRIPTION
Has been causing failures on minimal toydistro builds.

Also install colcon from debs into of pip, because that's sensible and cached in our mirror.