### PR TITLE
Install the bare minimum setuptools for colcon

### DIFF
--- a/tailor_distro/debian_templates/Dockerfile.j2
+++ b/tailor_distro/debian_templates/Dockerfile.j2
@@ -56,7 +56,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 {% if os_version == 'xenial' %}
 # xenial needs a newer setuptools for colcon to work
 RUN pip3 install -U \
-    setuptools
+    setuptools==39.2.0
 {% endif %}
 
 # Install build and run dependencies


### PR DESCRIPTION
Re: https://github.com/ros2/ros2/issues/512

Not providing a version will install the latest one, which is likely a bad idea for interop with other libraries.