### PR TITLE
Access to Private Github Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,47 @@ cd tailor-distro
 python -m pip install -e .
 ```
 
+## Repositories
+The commands provided by this package operate on a `rosdistro` git repository. All of the command examples below assume the default setup, but additional arguments can be specified on any of the commands.
+
+### Local Repository
+By default, the commands assume that you are running the commands from inside a locally cloned version of the repository, e.g.
+```
+tailor_manage query --distro ros1
+```
+
+You can also run from outside of a locally cloned version by providing the `--rosdistro-path` argument, a la
+```
+tailor_manage query --distro ros1 --rosdistro-path ~/awesome_distro/
+```
+
+The results of the commands will depend on the contents of the files as they're checked out (i.e. using the currently checked out branch). Some commands will change the files in the repository, but will *not* check them in.
+
+### Remote Repository
+You can also specify a remote GitHub repository in a number of ways and make the changes through the GitHub API. The first option is to use a link to the raw content, which is how [`$ROSDISTRO_INDEX_URL`](https://github.com/ros-infrastructure/ros_buildfarm/blob/master/doc/custom_rosdistro.rst) is set.
+```
+tailor_manage query --distro ros1 --rosdistro_url https://raw.githubusercontent.com/locusrobotics/toydistro/master/rosdistro/index.yaml
+tailor_manage query --distro ros1 --rosdistro_url $ROSDISTRO_INDEX_URL
+```
+Which branch to use is encoded into the url, but you can also override it with the `--rosdistro-branch` arg.
+```
+tailor_manage query --distro ros1 --rosdistro_url $ROSDISTRO_INDEX_URL --rosdistro-branch release/19.1
+```
+
+The url can also be the standard `https://github.com/ORG/REPO.git` url, i.e.
+```
+tailor_manage query --distro ros1 --rosdistro_url https://github.com/locusrobotics/toydistro.git
+```
+The branch will be default unless specified with `--rosdistro-branch`.
+
+Finally, you can also use a link to the tree that also specifies the branch, i.e.
+```
+tailor_manage pin --distro ros1 ros_comm --rosdistro-url https://github.com/locusrobotics/toydistro/tree/master
+tailor_manage pin --distro ros1 ros_comm --rosdistro-url https://github.com/locusrobotics/toydistro/tree/release/19.1
+```
+
+All of these commands will operate on the files checked into the requested branch. If the command changes the the files, it will prompt you before making the commit to the remote repository.
+
 ## Management
 
 This repository includes a variety of management commands:

--- a/tailor_distro/__init__.py
+++ b/tailor_distro/__init__.py
@@ -6,7 +6,10 @@ import pathlib
 import re
 import subprocess
 import sys
-import yaml
+try:
+    import yaml
+except ModuleNotFoundError:
+    pass
 
 from collections import namedtuple
 from typing import Iterable, List

--- a/tailor_distro/manage/__init__.py
+++ b/tailor_distro/manage/__init__.py
@@ -37,7 +37,7 @@ def main():
     verb = args.pop('verb')
 
     if verb is not None:
-        sys.exit(verb(rosdistro_repo, **args))
+        sys.exit(verb(rosdistro_repo=rosdistro_repo, **args))
     else:
         parser.print_help()
 

--- a/tailor_distro/manage/__init__.py
+++ b/tailor_distro/manage/__init__.py
@@ -8,6 +8,7 @@ from .import_ import ImportVerb  # noqa
 from .pin import PinVerb  # noqa
 from .query import QueryVerb  # noqa
 from .release import ReleaseVerb  # noqa
+from .rosdistro_repo import LocalROSDistro, RemoteROSDistro
 
 
 def main():
@@ -19,10 +20,24 @@ def main():
 
     args = vars(parser.parse_args())
 
+    # TODO(dlu): Maybe switch to add_mutually_exclusive_group
+    if args['rosdistro_path'] != '.' and args['rosdistro_url']:
+        raise RuntimeError('Cannot specify rosdistro using both path and url.')
+
+    distro_name = args.pop('distro')
+
+    if args['rosdistro_url']:
+        rosdistro_repo = RemoteROSDistro(args.pop('rosdistro_url'), args.pop('rosdistro_branch'), distro_name)
+        args.pop('rosdistro_path')
+    else:
+        rosdistro_repo = LocalROSDistro(args.pop('rosdistro_path'), distro_name)
+        args.pop('rosdistro_url')
+        args.pop('rosdistro_branch')
+
     verb = args.pop('verb')
 
     if verb is not None:
-        sys.exit(verb(**args))
+        sys.exit(verb(rosdistro_repo, **args))
     else:
         parser.print_help()
 

--- a/tailor_distro/manage/base.py
+++ b/tailor_distro/manage/base.py
@@ -1,18 +1,11 @@
 #!/usr/bin/python3
 import abc
 import click
-import difflib
 import github
 import json
-import re
 import pathlib
-import yaml
 
 from urllib.parse import urlsplit, urlunsplit
-from urllib.error import HTTPError
-from rosdistro import get_index, get_distribution, Index
-from rosdistro.distribution_file import create_distribution_file
-from rosdistro.writer import yaml_from_distribution_file
 
 
 def get_github_token():
@@ -35,82 +28,12 @@ def insert_auth_token(url, token):
     return urlunsplit(parts)
 
 
-BASE_URL = 'https://raw.githubusercontent.com'
-RAW_GH_PATTERN = re.compile(BASE_URL + '/(?P<repo>[^/]+/[^/]+)/(?P<branch>.+)/(?P<path>rosdistro/.+)')
-
-
-def get_distro_from_index(index, dist_name, type_='distribution'):
-    """
-       Portion of the logic from rosdistro.get_distribution
-    """
-    if dist_name not in index.distributions.keys():
-        valid_names = ', '.join(sorted(index.distributions.keys()))
-        raise RuntimeError("Unknown release: '{0}'. Valid release names are: {1}".format(dist_name, valid_names))
-    dist = index.distributions[dist_name]
-    if type_ not in dist.keys():
-        raise RuntimeError('unknown release type "%s"' % type_)
-
-    return dist[type_]
-
-
 class BaseVerb(metaclass=abc.ABCMeta):
     """Abstract base class for all distro management verbs."""
 
     @abc.abstractmethod
-    def execute(self, rosdistro_path, rosdistro_url, rosdistro_branch, distro):
-        if rosdistro_path != '.' and rosdistro_url is not None:
-            raise RuntimeError('Cannot specify rosdistro using both path and url.')
-
-        if rosdistro_url is not None:
-            m = RAW_GH_PATTERN.match(rosdistro_url)
-            if not m:
-                raise RuntimeError(f'Cannot use non-Github url ({rosdistro_url}) as the url at this time.')
-
-            gh = get_github_client()
-            self.repo = gh.get_repo(m.group('repo'))
-            self.path = m.group('path')
-            self.branch = rosdistro_branch
-
-            self.rosdistro_path = pathlib.Path(self.path)
-
-            try:
-                self.internal_index = get_index(rosdistro_url)
-                self.internal_distro = get_distribution(self.internal_index, distro)
-            except HTTPError:
-                # Only needed for private github repositories
-                distro_folder = self.rosdistro_path.parent
-                self.internal_index = Index(self.load_distro_file(self.path), str(distro_folder))
-
-                dist_url = get_distro_from_index(self.internal_index, distro)
-                if not isinstance(dist_url, list):
-                    data = self.load_distro_file(dist_url)
-                else:
-                    data = []
-                    for u in dist_url:
-                        data.append(self.load_distro_file(str(u)))
-                self.internal_distro = create_distribution_file(distro, data)
-        else:
-            self.repo = None
-
-            self.rosdistro_path = pathlib.Path(rosdistro_path)
-            internal_index_path = (self.rosdistro_path / 'rosdistro' / 'index.yaml').resolve()
-
-            if not internal_index_path.exists():
-                raise FileNotFoundError(f'No such file: {internal_index_path}')
-
-            self.internal_index = get_index(internal_index_path.as_uri())
-            self.internal_distro = get_distribution(self.internal_index, distro)
-
-        self.internal_distro_file = self.internal_index.distributions[distro]['distribution'][-1]
-
-    def load_distro_file(self, path):
-        if self.repo:
-            git_file = self.repo.get_contents(path, self.branch)
-            yaml_str = git_file.decoded_content.decode()
-        else:
-            path_obj = self.rosdistro_path / path
-            yaml_str = path_obj.open()
-        return yaml.safe_load(yaml_str)
+    def execute(self, rosdistro_repo):
+        self.rosdistro_repo = rosdistro_repo
 
     def register_arguments(self, parser):
         parser.set_defaults(verb=self.execute)
@@ -126,62 +49,3 @@ class BaseVerb(metaclass=abc.ABCMeta):
     def upstream_arg(self, parser):
         parser.add_argument('--upstream-distro', help="Upstream distribution override")
         parser.add_argument('--upstream-index', help="Upstream index URL override")
-
-    def load_upstream(self, distro, upstream_index, upstream_distro):
-        recipes = self.load_distro_file('config/recipes.yaml')
-        try:
-            info = recipes['common']['distributions'][distro]['upstream']
-        except KeyError:
-            info = None
-        index = get_index(upstream_index if upstream_index is not None else info['url'])
-        self.upstream_distro = get_distribution(
-            index,
-            upstream_distro if upstream_distro is not None else info['name']
-        )
-
-    def write_internal_distro(self, message=None):
-        new_contents = yaml_from_distribution_file(self.internal_distro)
-
-        if self.repo:
-            m = RAW_GH_PATTERN.match(self.internal_distro_file)
-            if m:
-                path = m['path']
-            else:
-                path = self.internal_distro_file
-
-            git_file = self.repo.get_contents(path, self.branch)
-            original_contents = git_file.decoded_content.decode()
-
-            print('\n'.join(difflib.unified_diff(original_contents.split('\n'), new_contents.split('\n'), lineterm='',
-                                                 fromfile=self.path, tofile='%s (modified)' % self.path)))
-
-            response = ''
-            try:
-                while not response or response[0] not in 'yn':
-                    response = input('Make commit? (y/n): ').strip().lower()
-            except KeyboardInterrupt:
-                print()
-                response = 'n'
-            except EOFError:
-                print()
-                response = 'n'
-
-            if response[0] == 'n':
-                print('Maybe later.')
-                return
-
-            if message is None:
-                try:
-                    while not message:
-                        message = input('Enter commit message: ').strip()
-                except KeyboardInterrupt:
-                    print('Aborting...')
-                    return
-                except EOFError:
-                    print('Aborting...')
-                    return
-
-            self.repo.update_file(path, message, new_contents, git_file.sha, branch=self.branch)
-        else:
-            distro_file_path = pathlib.Path(self.internal_distro_file[len('file://'):])
-            distro_file_path.write_text(new_contents)

--- a/tailor_distro/manage/base.py
+++ b/tailor_distro/manage/base.py
@@ -4,14 +4,13 @@ import click
 import difflib
 import github
 import json
-import os
 import re
 import pathlib
 import yaml
 
 from urllib.parse import urlsplit, urlunsplit
-from urllib import HTTPError
-from rosdistro import get_index, get_index_url, get_distribution, Index
+from urllib.error import HTTPError
+from rosdistro import get_index, get_distribution, Index
 from rosdistro.distribution_file import create_distribution_file
 from rosdistro.writer import yaml_from_distribution_file
 
@@ -39,60 +38,9 @@ def insert_auth_token(url, token):
 RAW_GH_PATTERN = re.compile('https://raw.githubusercontent.com/(?P<repo>[^/]+/[^/]+)/(?P<branch>[^/]+)/(?P<path>.+)')
 
 
-def _load_github_helper(url):
-    m = RAW_GH_PATTERN.match(url)
-    if not m:
-        raise RuntimeError('Cannot parse raw github url: {}'.format(url))
-    gh = get_github_client()
-    repo = gh.get_repo(m.group('repo'))
-    return repo, m.group('path'), m.group('branch')
-
-
-def load_github_file(url):
-    repo, path, branch = _load_github_helper(url)
-    git_file = repo.get_contents(path, branch)
-    yaml_str = git_file.decoded_content.decode()
-    return yaml.safe_load(yaml_str)
-
-
-def write_github_file(url, new_contents, message='[no message given]'):
-    repo, path, branch = _load_github_helper(url)
-    git_file = repo.get_contents(path, branch)
-    original_contents = git_file.decoded_content.decode()
-
-    print('\n'.join(difflib.unified_diff(original_contents.split('\n'), new_contents.split('\n'), lineterm='',
-                                         fromfile=path, tofile='%s (modified)' % path)))
-
-    response = ''
-    try:
-        while not response or response[0] not in 'yn':
-            response = input('Make commit "{}"? (y/n): '.format(message)).strip().lower()
-    except KeyboardInterrupt:
-        print()
-        response = 'n'
-    except EOFError:
-        print()
-        response = 'n'
-
-    if response[0] == 'n':
-        print('Maybe later.')
-        return
-
-    repo.update_file(path, message, new_contents, git_file.sha, branch=branch)
-
-
-def get_private_index(internal_index_path):
+def get_distro_from_index(index, dist_name, type_='distribution'):
     """
-       Version of rosdistro.get_index that can load from a private repository
-    """
-    data = load_github_file(internal_index_path)
-    base_url = os.path.dirname(internal_index_path)
-    return Index(data, base_url)
-
-
-def get_private_distro(index, dist_name, type_='distribution'):
-    """
-        Version of rosdistro.get_distribution that can load from a private repository
+       Portion of the logic from rosdistro.get_distribution
     """
     if dist_name not in index.distributions.keys():
         valid_names = ', '.join(sorted(index.distributions.keys()))
@@ -100,15 +48,8 @@ def get_private_distro(index, dist_name, type_='distribution'):
     dist = index.distributions[dist_name]
     if type_ not in dist.keys():
         raise RuntimeError('unknown release type "%s"' % type_)
-    url = dist[type_]
 
-    if not isinstance(url, list):
-        data = load_github_file(url)
-    else:
-        data = []
-        for u in url:
-            data.append(load_github_file(u))
-    return create_distribution_file(dist_name, data)
+    return dist[type_]
 
 
 class BaseVerb(metaclass=abc.ABCMeta):
@@ -116,27 +57,61 @@ class BaseVerb(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def execute(self, rosdistro_path, distro):
-        self.rosdistro_path = rosdistro_path
-        index_path = rosdistro_path / 'rosdistro' / 'index.yaml'
-        if index_path.exists():
-            internal_index_path = index_path.resolve().as_uri()
-        else:
-            internal_index_path = get_index_url()
+        m = RAW_GH_PATTERN.match(rosdistro_path)
+        if m:
+            gh = get_github_client()
+            self.repo = gh.get_repo(m.group('repo'))
+            self.path = m.group('path')
+            self.branch = m.group('branch')
 
-        try:
+            self.rosdistro_path = pathlib.Path(self.path)
+
+            try:
+                self.internal_index = get_index(rosdistro_path)
+                self.internal_distro = get_distribution(self.internal_index, distro)
+            except HTTPError:
+                # Only needed for private github repositories
+                distro_folder = self.rosdistro_path.parent
+                self.internal_index = Index(self.load_distro_file(self.path), str(distro_folder))
+
+                dist_url = get_distro_from_index(self.internal_index, distro)
+                if not isinstance(dist_url, list):
+                    data = self.load_distro_file(dist_url)
+                else:
+                    data = []
+                    for u in dist_url:
+                        data.append(self.load_distro_file(str(u)))
+                self.internal_distro = create_distribution_file(distro, data)
+        else:
+            self.repo = None
+
+            self.rosdistro_path = pathlib.Path(rosdistro_path)
+            if not self.rosdistro_path.exists():
+                if 'http' in rosdistro_path:
+                    raise RuntimeError(f'Cannot use non-Github path ({rosdistro_path}) at this time.')
+                else:
+                    raise RuntimeError(f'Cannot parse rosdistro_path ({rosdistro_path} as github path or '
+                                       'find it as local file.')
+            internal_index_path = (rosdistro_path / 'rosdistro' / 'index.yaml').resolve().as_uri()
             self.internal_index = get_index(internal_index_path)
             self.internal_distro = get_distribution(self.internal_index, distro)
-        except HTTPError:
-            self.internal_index = get_private_index(internal_index_path)
-            self.internal_distro = get_private_distro(self.internal_index, distro)
 
         self.internal_distro_file = self.internal_index.distributions[distro]['distribution'][-1]
+
+    def load_distro_file(self, path):
+        if self.repo:
+            git_file = self.repo.get_contents(path, self.branch)
+            yaml_str = git_file.decoded_content.decode()
+        else:
+            path_obj = self.rosdistro_path / path
+            yaml_str = path_obj.open()
+        return yaml.safe_load(yaml_str)
 
     def register_arguments(self, parser):
         parser.set_defaults(verb=self.execute)
         parser.add_argument('--distro', required=True, help="Distribution on which to operate")
         # TODO(pbovbel) Use path relative to package?
-        parser.add_argument('--rosdistro-path', type=pathlib.Path, default='.', help="Index URL override")
+        parser.add_argument('--rosdistro-path', default='.', help="Index URL override")
 
     def repositories_arg(self, parser):
         parser.add_argument('repositories', nargs='*', metavar='REPO', help="Repositories to operate on")
@@ -146,7 +121,7 @@ class BaseVerb(metaclass=abc.ABCMeta):
         parser.add_argument('--upstream-index', help="Upstream index URL override")
 
     def load_upstream(self, distro, upstream_index, upstream_distro):
-        recipes = yaml.safe_load((self.rosdistro_path / 'config' / 'recipes.yaml').open())
+        recipes = self.load_distro_file('config/recipes.yaml')
         try:
             info = recipes['common']['distributions'][distro]['upstream']
         except KeyError:
@@ -157,12 +132,32 @@ class BaseVerb(metaclass=abc.ABCMeta):
             upstream_distro if upstream_distro is not None else info['name']
         )
 
-    def write_internal_distro(self):
+    def write_internal_distro(self, message='[no message]'):
         new_contents = yaml_from_distribution_file(self.internal_distro)
 
-        m = RAW_GH_PATTERN.match(self.internal_distro_file)
-        if not m:
+        if self.repo:
+            git_file = self.repo.get_contents(self.path, self.branch)
+            original_contents = git_file.decoded_content.decode()
+
+            print('\n'.join(difflib.unified_diff(original_contents.split('\n'), new_contents.split('\n'), lineterm='',
+                                                 fromfile=self.path, tofile='%s (modified)' % self.path)))
+
+            response = ''
+            try:
+                while not response or response[0] not in 'yn':
+                    response = input('Make commit "{}"? (y/n): '.format(message)).strip().lower()
+            except KeyboardInterrupt:
+                print()
+                response = 'n'
+            except EOFError:
+                print()
+                response = 'n'
+
+            if response[0] == 'n':
+                print('Maybe later.')
+                return
+
+            self.repo.update_file(self.path, message, new_contents, git_file.sha, branch=self.branch)
+        else:
             distro_file_path = pathlib.Path(self.internal_distro_file[len('file://'):])
             distro_file_path.write_text(new_contents)
-        else:
-            write_github_file(self.internal_distro_file, new_contents)

--- a/tailor_distro/manage/base.py
+++ b/tailor_distro/manage/base.py
@@ -136,7 +136,13 @@ class BaseVerb(metaclass=abc.ABCMeta):
         new_contents = yaml_from_distribution_file(self.internal_distro)
 
         if self.repo:
-            git_file = self.repo.get_contents(self.path, self.branch)
+            m = RAW_GH_PATTERN.match(self.internal_distro_file)
+            if m:
+                path = m['path']
+            else:
+                path = self.internal_distro_file
+
+            git_file = self.repo.get_contents(path, self.branch)
             original_contents = git_file.decoded_content.decode()
 
             print('\n'.join(difflib.unified_diff(original_contents.split('\n'), new_contents.split('\n'), lineterm='',
@@ -157,7 +163,7 @@ class BaseVerb(metaclass=abc.ABCMeta):
                 print('Maybe later.')
                 return
 
-            self.repo.update_file(self.path, message, new_contents, git_file.sha, branch=self.branch)
+            self.repo.update_file(path, message, new_contents, git_file.sha, branch=self.branch)
         else:
             distro_file_path = pathlib.Path(self.internal_distro_file[len('file://'):])
             distro_file_path.write_text(new_contents)

--- a/tailor_distro/manage/base.py
+++ b/tailor_distro/manage/base.py
@@ -92,7 +92,7 @@ class BaseVerb(metaclass=abc.ABCMeta):
                 else:
                     raise RuntimeError(f'Cannot parse rosdistro_path ({rosdistro_path} as github path or '
                                        'find it as local file.')
-            internal_index_path = (rosdistro_path / 'rosdistro' / 'index.yaml').resolve().as_uri()
+            internal_index_path = (self.rosdistro_path / 'rosdistro' / 'index.yaml').resolve().as_uri()
             self.internal_index = get_index(internal_index_path)
             self.internal_distro = get_distribution(self.internal_index, distro)
 

--- a/tailor_distro/manage/base.py
+++ b/tailor_distro/manage/base.py
@@ -41,7 +41,7 @@ class BaseVerb(metaclass=abc.ABCMeta):
         # TODO(pbovbel) Use path relative to package?
         parser.add_argument('--rosdistro-path', default='.', help="Index URL override")
         parser.add_argument('--rosdistro-url', help="Index URL override via Github")
-        parser.add_argument('--rosdistro-branch', default='master', help="Branch of rosdistro to operate on")
+        parser.add_argument('--rosdistro-branch', help="Branch of rosdistro to operate on")
 
     def repositories_arg(self, parser):
         parser.add_argument('repositories', nargs='*', metavar='REPO', help="Repositories to operate on")

--- a/tailor_distro/manage/base.py
+++ b/tailor_distro/manage/base.py
@@ -132,7 +132,7 @@ class BaseVerb(metaclass=abc.ABCMeta):
             upstream_distro if upstream_distro is not None else info['name']
         )
 
-    def write_internal_distro(self, message='[no message]'):
+    def write_internal_distro(self, message=None):
         new_contents = yaml_from_distribution_file(self.internal_distro)
 
         if self.repo:
@@ -151,7 +151,7 @@ class BaseVerb(metaclass=abc.ABCMeta):
             response = ''
             try:
                 while not response or response[0] not in 'yn':
-                    response = input('Make commit "{}"? (y/n): '.format(message)).strip().lower()
+                    response = input('Make commit? (y/n): ').strip().lower()
             except KeyboardInterrupt:
                 print()
                 response = 'n'
@@ -162,6 +162,17 @@ class BaseVerb(metaclass=abc.ABCMeta):
             if response[0] == 'n':
                 print('Maybe later.')
                 return
+
+            if message is None:
+                try:
+                    while not message:
+                        message = input('Enter commit message: ').strip()
+                except KeyboardInterrupt:
+                    print('Aborting...')
+                    return
+                except EOFError:
+                    print('Aborting...')
+                    return
 
             self.repo.update_file(path, message, new_contents, git_file.sha, branch=self.branch)
         else:

--- a/tailor_distro/manage/compare.py
+++ b/tailor_distro/manage/compare.py
@@ -18,8 +18,9 @@ class CompareVerb(BaseVerb):
         parser.add_argument('--missing', action='store_true', help="Display repositories missing downstream")
         parser.add_argument('--raw', action='store_true', help="Output only package names")
 
-    def execute(self, repositories, rosdistro_path, distro, upstream_index, upstream_distro, missing, raw):
-        super().execute(rosdistro_path, distro)
+    def execute(self, repositories, rosdistro_path, rosdistro_url, rosdistro_branch,
+                distro, upstream_index, upstream_distro, missing, raw):
+        super().execute(rosdistro_path, rosdistro_url, rosdistro_branch, distro)
         self.load_upstream(distro, upstream_index, upstream_distro)
 
         if missing:

--- a/tailor_distro/manage/import_.py
+++ b/tailor_distro/manage/import_.py
@@ -16,8 +16,9 @@ class ImportVerb(BaseVerb):
         self.repositories_arg(parser)
         self.upstream_arg(parser)
 
-    def execute(self, repositories, rosdistro_path, distro, upstream_index, upstream_distro):
-        super().execute(rosdistro_path, distro)
+    def execute(self, repositories, rosdistro_path, rosdistro_url, rosdistro_branch,
+                distro, upstream_index, upstream_distro):
+        super().execute(rosdistro_path, rosdistro_url, rosdistro_branch, distro)
         self.load_upstream(distro, upstream_index, upstream_distro)
 
         for repo in repositories:

--- a/tailor_distro/manage/import_.py
+++ b/tailor_distro/manage/import_.py
@@ -16,15 +16,14 @@ class ImportVerb(BaseVerb):
         self.repositories_arg(parser)
         self.upstream_arg(parser)
 
-    def execute(self, repositories, rosdistro_path, rosdistro_url, rosdistro_branch,
-                distro, upstream_index, upstream_distro):
-        super().execute(rosdistro_path, rosdistro_url, rosdistro_branch, distro)
-        self.load_upstream(distro, upstream_index, upstream_distro)
+    def execute(self, rosdistro_repo, repositories, upstream_index, upstream_distro):
+        super().execute(rosdistro_repo)
+        upstream = self.rosdistro_repo.get_upstream_distro(upstream_index, upstream_distro)
 
         for repo in repositories:
             try:
-                source_repo_data = self.upstream_distro.repositories[repo].source_repository.get_data()
-                status = self.upstream_distro.repositories[repo].source_repository.status
+                source_repo_data = upstream.repositories[repo].source_repository.get_data()
+                status = upstream.repositories[repo].source_repository.status
             except (KeyError, AttributeError):
                 click.echo(click.style(f'Unable to find source entry for repo {repo} in upstream distro', fg='yellow'),
                            err=True)
@@ -35,12 +34,12 @@ class ImportVerb(BaseVerb):
 
             click.echo(f"Writing source entry for repo {repo} ...")
 
-            try:
-                self.internal_distro.repositories[repo].source_repository = \
-                    SourceRepositorySpecification(repo, source_repo_data)
-            except KeyError:
-                self.internal_distro.repositories[repo] = Repository(
+            repo_entry = self.rosdistro_repo[repo]
+            if repo_entry:
+                repo_entry.source_repository = SourceRepositorySpecification(repo, source_repo_data)
+            else:
+                self.rosdistro_repo.set_repo(repo, Repository(
                     name=repo, doc_data={}, release_data={}, status_data={'status': status},
-                    source_data=source_repo_data)
+                    source_data=source_repo_data))
 
-        self.write_internal_distro()
+        self.rosdistro_repo.write_internal_distro('Importing {} from {}'.format('/'.join(repositories), upstream_index))

--- a/tailor_distro/manage/import_.py
+++ b/tailor_distro/manage/import_.py
@@ -20,6 +20,10 @@ class ImportVerb(BaseVerb):
         super().execute(rosdistro_repo)
         upstream = self.rosdistro_repo.get_upstream_distro(upstream_index, upstream_distro)
 
+        if not repositories:
+            click.echo(click.style('No repositories specified.', fg='yellow'), err=True)
+            return
+
         for repo in repositories:
             try:
                 source_repo_data = upstream.repositories[repo].source_repository.get_data()
@@ -42,4 +46,5 @@ class ImportVerb(BaseVerb):
                     name=repo, doc_data={}, release_data={}, status_data={'status': status},
                     source_data=source_repo_data))
 
-        self.rosdistro_repo.write_internal_distro('Importing {} from {}'.format('/'.join(repositories), upstream_index))
+        msg = 'Importing {} from {}'.format('/'.join(repositories), upstream_index or 'upstream')
+        self.rosdistro_repo.write_internal_distro(msg)

--- a/tailor_distro/manage/pin.py
+++ b/tailor_distro/manage/pin.py
@@ -19,14 +19,14 @@ class PinVerb(BaseVerb):
         super().register_arguments(parser)
         self.repositories_arg(parser)
 
-    def execute(self, repositories, rosdistro_path, rosdistro_url, rosdistro_branch, distro):
-        super().execute(rosdistro_path, rosdistro_url, rosdistro_branch, distro)
+    def execute(self, rosdistro_repo, repositories):
+        super().execute(rosdistro_repo)
 
         github_client = get_github_client()
 
         for repo in repositories:
             click.echo(f'Pinning repo {repo} ...', err=True)
-            data = self.internal_distro.repositories[repo]
+            data = self.rosdistro_repo[repo]
 
             try:
                 if data.release_repository.url != data.source_repository.url:
@@ -86,4 +86,4 @@ class PinVerb(BaseVerb):
             # TODO(pbovbel) store name of pinner?
             data.status_description = f"Pinned {age} commits behind {source_branch} on {datetime.datetime.now()}"
 
-        self.write_internal_distro()
+        self.rosdistro_repo.write_internal_distro('Pinning {}'.format('/'.join(repositories)))

--- a/tailor_distro/manage/pin.py
+++ b/tailor_distro/manage/pin.py
@@ -24,6 +24,8 @@ class PinVerb(BaseVerb):
 
         github_client = get_github_client()
 
+        actions = []
+
         for repo in repositories:
             click.echo(f'Pinning repo {repo} ...', err=True)
             data = self.rosdistro_repo[repo]
@@ -77,13 +79,15 @@ class PinVerb(BaseVerb):
                 continue
 
             if data.release_repository is None:
+                actions.append(f'{repo} ({latest_tag})')
                 data.release_repository = ReleaseRepositorySpecification(
                     repo_name, {'version': latest_tag, 'url': source_url, 'tags': {'release': '{{ version }}'}}
                 )
             else:
+                actions.append(f'{repo} ({data.release_repository.version} -> {latest_tag})')
                 data.release_repository.version = latest_tag
 
             # TODO(pbovbel) store name of pinner?
             data.status_description = f"Pinned {age} commits behind {source_branch} on {datetime.datetime.now()}"
 
-        self.rosdistro_repo.write_internal_distro('Pinning {}'.format('/'.join(repositories)))
+        self.rosdistro_repo.write_internal_distro('Pinning {}'.format(', '.join(actions)))

--- a/tailor_distro/manage/pin.py
+++ b/tailor_distro/manage/pin.py
@@ -19,8 +19,8 @@ class PinVerb(BaseVerb):
         super().register_arguments(parser)
         self.repositories_arg(parser)
 
-    def execute(self, repositories, rosdistro_path, distro):
-        super().execute(rosdistro_path, distro)
+    def execute(self, repositories, rosdistro_path, rosdistro_url, rosdistro_branch, distro):
+        super().execute(rosdistro_path, rosdistro_url, rosdistro_branch, distro)
 
         github_client = get_github_client()
 

--- a/tailor_distro/manage/query.py
+++ b/tailor_distro/manage/query.py
@@ -17,30 +17,23 @@ class QueryVerb(BaseVerb):
         group.add_argument('--pinned', action='store_true')
         group.add_argument('--unpinned', action='store_true')
 
-    def execute(self, distro, rosdistro_path, rosdistro_url, rosdistro_branch,
-                name_pattern, url_pattern, pinned, unpinned):
-        super().execute(rosdistro_path, rosdistro_url, rosdistro_branch, distro)
-        repos = set(self.internal_distro.repositories.keys())
+    def execute(self, rosdistro_repo, name_pattern, url_pattern, pinned, unpinned):
+        super().execute(rosdistro_repo)
+        repos = self.rosdistro_repo.get_repo_names()
         if name_pattern is not None:
-            repos &= {
-                repo for repo, data in self.internal_distro.repositories.items()
-                if name_pattern.match(repo)
-            }
+            repos = set([repo for repo in repos if name_pattern.match(repo)])
         if url_pattern is not None:
-            repos &= {
-                repo for repo, data in self.internal_distro.repositories.items()
-                if data.source_repository is not None and url_pattern.match(data.source_repository.url)
-            }
+            repos = set([repo for repo in repos
+                         if self.rosdistro_repo[repo].source_repository is not None and
+                         url_pattern.match(self.rosdistro_repo[repo].source_repository.url)])
 
         if pinned:
-            repos &= {
-                repo for repo, data in self.internal_distro.repositories.items()
-                if data.release_repository and data.release_repository.version is not None
-            }
+            repos = set([repo for repo in repos
+                         if self.rosdistro_repo[repo].release_repository and
+                         self.rosdistro_repo[repo].release_repository.version is not None])
         elif unpinned:
-            repos &= {
-                repo for repo, data in self.internal_distro.repositories.items()
-                if data.release_repository is None or data.release_repository.version is None
-            }
+            repos = set([repo for repo in repos
+                         if self.rosdistro_repo[repo].release_repository is None or
+                         self.rosdistro_repo[repo].release_repository.version is None])
 
         click.echo(' '.join(sorted(repos)))

--- a/tailor_distro/manage/query.py
+++ b/tailor_distro/manage/query.py
@@ -17,8 +17,9 @@ class QueryVerb(BaseVerb):
         group.add_argument('--pinned', action='store_true')
         group.add_argument('--unpinned', action='store_true')
 
-    def execute(self, distro, rosdistro_path, name_pattern, url_pattern, pinned, unpinned):
-        super().execute(rosdistro_path, distro)
+    def execute(self, distro, rosdistro_path, rosdistro_url, rosdistro_branch,
+                name_pattern, url_pattern, pinned, unpinned):
+        super().execute(rosdistro_path, rosdistro_url, rosdistro_branch, distro)
         repos = set(self.internal_distro.repositories.keys())
         if name_pattern is not None:
             repos &= {

--- a/tailor_distro/manage/release.py
+++ b/tailor_distro/manage/release.py
@@ -22,22 +22,20 @@ class ReleaseVerb(BaseVerb):
         self.repositories_arg(parser)
         parser.add_argument('--release-version', required=True, type=str, help="Release version (e.g. '19.1')")
 
-    def execute(self, repositories, rosdistro_path, rosdistro_url, rosdistro_branch, distro, release_version):
-        super().execute(rosdistro_path, rosdistro_url, rosdistro_branch, distro)
+    def execute(self, rosdistro_repo, repositories, release_version):
+        super().execute(rosdistro_repo)
 
         release_branch_name = f'release/{release_version}'
 
-        rosdistro_repo = git.Repo(rosdistro_path)
-
-        github_token = get_github_token()
-
-        if str(rosdistro_repo.active_branch) != release_branch_name:
+        if self.rosdistro_repo.get_branch_name() != release_branch_name:
             click.echo(click.style(f"rosdistro should be on '{release_branch_name}' branch", fg='red'), err=True)
             return 1
 
+        github_token = get_github_token()
+
         for name in repositories:
             click.echo(click.style(f"---\nReleasing repository '{name}'", fg='green'), err=True)
-            data = self.internal_distro.repositories[name]
+            data = self.rosdistro_repo[name]
             repo_url = data.source_repository.url
             source_version = data.source_repository.version
 
@@ -111,9 +109,9 @@ class ReleaseVerb(BaseVerb):
                 self._update_rosdistro_entry(name, latest_tag, release_branch_name)
 
     def _update_rosdistro_entry(self, name, latest_tag, release_branch_name):
-        click.echo(click.style(f"Updating rosdistro with release of '{name}' as version {latest_tag}", fg='yellow'),
-                   err=True)
-        data = self.internal_distro.repositories[name]
+        msg = f"Updating rosdistro with release of '{name}' as version {latest_tag}"
+        click.echo(click.style(msg, fg='yellow'), err=True)
+        data = self.rosdistro_repo[name]
         data.source_repository.version = release_branch_name
         if data.release_repository is None:
             data.release_repository = ReleaseRepositorySpecification(
@@ -122,7 +120,7 @@ class ReleaseVerb(BaseVerb):
         else:
             data.release_repository.version = latest_tag
 
-        self.write_internal_distro()
+        self.rosdistro_repo.write_internal_distro(msg)
 
     def _get_current_tag(self, repo, release_version):
         click.echo(click.style(f"Checking for a tag to have been created...", fg='green'), err=True)

--- a/tailor_distro/manage/release.py
+++ b/tailor_distro/manage/release.py
@@ -82,8 +82,8 @@ class ReleaseVerb(BaseVerb):
                         run_command(changelog_command + ['--all'], cwd=temp_dir)
                     else:
                         # Need to print stdout/stderr, otherwise they get swallowed
-                        print(e.stdout)
-                        print(e.stderr)
+                        click.echo(e.stdout)
+                        click.echo(e.stderr, err=True)
                         raise
 
                 repo.index.add(['*'])

--- a/tailor_distro/manage/release.py
+++ b/tailor_distro/manage/release.py
@@ -22,8 +22,8 @@ class ReleaseVerb(BaseVerb):
         self.repositories_arg(parser)
         parser.add_argument('--release-version', required=True, type=str, help="Release version (e.g. '19.1')")
 
-    def execute(self, repositories, rosdistro_path, distro, release_version):
-        super().execute(rosdistro_path, distro)
+    def execute(self, repositories, rosdistro_path, rosdistro_url, rosdistro_branch, distro, release_version):
+        super().execute(rosdistro_path, rosdistro_url, rosdistro_branch, distro)
 
         release_branch_name = f'release/{release_version}'
 

--- a/tailor_distro/manage/rosdistro_repo.py
+++ b/tailor_distro/manage/rosdistro_repo.py
@@ -1,0 +1,191 @@
+import abc
+import difflib
+import git
+import pathlib
+import re
+from rosdistro import get_index, get_distribution, Index
+from rosdistro.distribution_file import create_distribution_file
+from rosdistro.writer import yaml_from_distribution_file
+from urllib.error import HTTPError
+import yaml
+
+from .base import get_github_client
+
+
+GITHUB_PATTERN = re.compile('https?://github.com/(?P<org>[^/]+)/(?P<repo>.+)\.git')
+GITHUB_BRANCH_PATTERN = re.compile('https://github.com/(?P<org>[^/]+)/(?P<repo>[^/]+)/tree/(?P<branch>.*)')
+RAW_GITHUB_PATTERN = re.compile(r'https://raw.githubusercontent.com/'
+                                r'(?P<repo>[^/]+/[^/]+)/(?P<branch>.+)/(?P<path>rosdistro/.+)')
+REPO_URL_PATTERNS = [GITHUB_PATTERN, GITHUB_BRANCH_PATTERN, RAW_GITHUB_PATTERN]
+
+
+def parse_repo_url(url):
+    for pattern in REPO_URL_PATTERNS:
+        m = pattern.match(url)
+        if m:
+            return m.groupdict()
+
+
+class RepositoryBase(metaclass=abc.ABCMeta):
+    """
+        Abstract class for operating on a rosdistro repository.
+        Implementing classes should set
+         * self.internal_index (rosdistro.Index)
+         * self.interal_distro (rosdistro.Distribution)
+         * self.internal_distro_path (relative path to distro file)
+         * self.distro_name (string name of distro)
+        (and implement the abstract methods)
+    """
+
+    @abc.abstractmethod
+    def read_file(self, path):
+        """ Read the specified relative path and return the contents """
+
+    @abc.abstractmethod
+    def write_file(self, path, new_contents, message=None):
+        """ Write the new contents to the given relative path. Optional message describes the change """
+
+    def read_yaml_file(self, path):
+        """ Read the specified relative path, and return the contents parsed as a yaml file """
+        return yaml.safe_load(self.read_file(path))
+
+    @abc.abstractmethod
+    def get_branch_name(self):
+        """ Return a string of the branch name we're operating on """
+
+    def __getitem__(self, key):
+        """ Return the repositories entry corresponding with key """
+        return self.internal_distro.repositories.get(key)
+
+    def get_repo_names(self):
+        return set(self.internal_distro.repositories.keys())
+
+    def get_upstream_distro(self, upstream_index, upstream_distro):
+        recipes = self.read_yaml_file('config/recipes.yaml')
+        try:
+            info = recipes['common']['distributions'][self.distro_name]['upstream']
+        except KeyError:
+            info = None
+
+        index = get_index(upstream_index if upstream_index is not None else info['url'])
+        return get_distribution(index, upstream_distro if upstream_distro is not None else info['name'])
+
+    def write_internal_distro(self, message=None):
+        new_contents = yaml_from_distribution_file(self.internal_distro)
+        self.write_file(self.internal_distro_path, new_contents, message)
+
+
+class LocalROSDistro(RepositoryBase):
+    def __init__(self, rosdistro_path, distro_name):
+        self.rosdistro_path = pathlib.Path(rosdistro_path)
+        self.distro_name = distro_name
+        internal_index_path = (self.rosdistro_path / 'rosdistro' / 'index.yaml').resolve()
+
+        if not internal_index_path.exists():
+            raise FileNotFoundError(f'No such file: {internal_index_path}')
+
+        self.internal_index = get_index(internal_index_path.as_uri())
+        self.internal_distro = get_distribution(self.internal_index, distro_name)
+
+        self.internal_distro_path = self.internal_index.distributions[distro_name]['distribution'][-1][len('file://'):]
+
+    def read_file(self, path):
+        path_obj = self.rosdistro_path / path
+        with path_obj.open() as f:
+            return f.read()
+
+    def write_file(self, path, new_contents, message=None):
+        path_obj = pathlib.Path(path)
+        path_obj.write_text(new_contents)
+
+    def get_branch_name(self):
+        rosdistro_repo = git.Repo(self.rosdistro_path)
+        return str(rosdistro_repo.active_branch)
+
+
+def get_distro_from_index(index, dist_name, type_='distribution'):
+    """
+       Portion of the logic from rosdistro.get_distribution
+    """
+    if dist_name not in index.distributions.keys():
+        valid_names = ', '.join(sorted(index.distributions.keys()))
+        raise RuntimeError("Unknown release: '{0}'. Valid release names are: {1}".format(dist_name, valid_names))
+    dist = index.distributions[dist_name]
+    if type_ not in dist.keys():
+        raise RuntimeError('unknown release type "%s"' % type_)
+
+    return dist[type_]
+
+
+class RemoteROSDistro(RepositoryBase):
+    def __init__(self, rosdistro_url, rosdistro_branch, distro_name):
+        repo_info = parse_repo_url(rosdistro_url)
+
+        if not repo_info:
+            raise RuntimeError(f'Cannot parse rosdistro_url {rosdistro_url}')
+
+        gh = get_github_client()
+        self.repo = gh.get_repo(repo_info['repo'])
+        self.path = repo_info['path']
+        self.branch = rosdistro_branch or repo_info['branch']
+
+        try:
+            self.internal_index = get_index(rosdistro_url)
+            self.internal_distro = get_distribution(self.internal_index, distro_name)
+        except HTTPError:
+            # Only needed for private github repositories
+            distro_folder = pathlib.Path(self.path).parent
+            self.internal_index = Index(self.read_yaml_file(self.path), str(distro_folder))
+
+            dist_url = get_distro_from_index(self.internal_index, distro_name)
+            if not isinstance(dist_url, list):
+                data = self.read_yaml_file(dist_url)
+            else:
+                data = []
+                for u in dist_url:
+                    data.append(self.read_yaml_file(str(u)))
+            self.internal_distro = create_distribution_file(distro_name, data)
+
+        self.internal_distro_path = self.internal_index.distributions[distro_name]['distribution'][-1]
+
+    def read_file(self, path):
+        git_file = self.repo.get_contents(path, self.branch)
+        return git_file.decoded_content.decode()
+
+    def write_file(self, path, new_contents, message=None, make_confirmation=True):
+        git_file = self.repo.get_contents(path, self.branch)
+        if make_confirmation:
+            # TODO(dlu): Should click be used for something?
+            original_contents = git_file.decoded_content.decode()
+            print('\n'.join(difflib.unified_diff(original_contents.split('\n'), new_contents.split('\n'), lineterm='',
+                                                 fromfile=path, tofile='%s (modified)' % path)))
+            response = ''
+            try:
+                while not response or response[0] not in 'yn':
+                    response = input('Make commit? (y/n): ').strip().lower()
+            except KeyboardInterrupt:
+                print()
+                response = 'n'
+            except EOFError:
+                print()
+                response = 'n'
+
+            if response[0] == 'n':
+                print('Maybe later.')
+                return
+
+        if message is None:
+            try:
+                while not message:
+                    message = input('Enter commit message: ').strip()
+            except KeyboardInterrupt:
+                print('Aborting...')
+                return
+            except EOFError:
+                print('Aborting...')
+                return
+
+        self.repo.update_file(path, message, new_contents, git_file.sha, branch=self.branch)
+
+    def get_branch_name(self):
+        return self.branch

--- a/tailor_distro/manage/rosdistro_repo.py
+++ b/tailor_distro/manage/rosdistro_repo.py
@@ -12,8 +12,8 @@ import yaml
 from .base import get_github_client
 
 
-GITHUB_PATTERN = re.compile('https?://github.com/(?P<repo>[^/]+/.+)\.git')
-GITHUB_BRANCH_PATTERN = re.compile('https://github.com/(?P<repo>[^/]+/[^/]+)/tree/(?P<branch>.*)')
+GITHUB_PATTERN = re.compile(r'https?://github.com/(?P<repo>[^/]+/.+)\.git')
+GITHUB_BRANCH_PATTERN = re.compile(r'https://github.com/(?P<repo>[^/]+/[^/]+)/tree/(?P<branch>.*)')
 RAW_GITHUB_PATTERN = re.compile(r'https://raw.githubusercontent.com/'
                                 r'(?P<repo>[^/]+/[^/]+)/(?P<branch>.+)/(?P<path>rosdistro/.+)')
 REPO_URL_PATTERNS = [GITHUB_PATTERN, GITHUB_BRANCH_PATTERN, RAW_GITHUB_PATTERN]


### PR DESCRIPTION
The `rosdistro` Python package does not make use of the `PyGithub` and as a result `rosdistro.get_index` does not have the ability to read or write private github files. 

However, `tailor` does use `PyGithub` and has mechanisms for reading private files. This PR does four things with this idea. 

 1. The default operation assumes `rosdistro_path` is the current directory or otherwise specified. If that doesn't work, it will throw an error. The first change is to make it so that if it doesn't exist, the [`get_index_url`](https://github.com/ros-infrastructure/rosdistro/blob/master/src/rosdistro/__init__.py#L71) functionality is used instead.
 1. Creates `load_private_raw_file` which replaces [`load_url`](https://github.com/ros-infrastructure/rosdistro/blob/master/src/rosdistro/loader.py#L46) with a `PyGithub` interface. Because the URL is often of the format `"https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml"`, this has to be parsed to get the github repo, branch and path, which can then be fed into `PyGithub`.
 1. Creates `get_private_index` and `get_private_distro` which work like `rosdistro.get_index` and `rosdistro.get_distribution`(if they had the ability to get private files from github)
 1. Finally, also creates `write_private_raw_file` which gives the ability to write back to github when you're done. 

I admittedly haven't tested this within the `tailor` infrastructure, but have tested the individual pieces separately. I'm very open to suggestions since this is not my project. 