### PR TITLE
Compare source urls and release versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,11 +25,12 @@ install_requires =
     rosdistro ==0.7.4
 packages = find:
 setup_requires =
-    pytest-runner
+    pytest-runner ==5.1
 tests_require =
-    pytest
-    pytest-mypy
-    pytest-flake8
+    pytest ==5.1.3
+    pytest-mypy ==0.4.1
+    pytest-flake8 ==1.0.4
+    pytest-flakes ==4.0.0
 
 [options.entry_points]
 console_scripts =
@@ -44,7 +45,7 @@ console_scripts =
 test=pytest
 
 [tool:pytest]
-addopts = --verbose --junitxml=test-results.xml --mypy --flake8
+addopts = --verbose --junitxml=test-results.xml --mypy --flakes --flake8
 pep8maxlinelength = 120
 
 [flake8]

--- a/tailor_distro/manage/compare.py
+++ b/tailor_distro/manage/compare.py
@@ -53,8 +53,8 @@ class CompareVerb(BaseVerb):
             diff['name'] = {'unchanged': repo}
 
         diff_url = build_diff(
-            upstream=get_url(self.upstream_distro.repositories[repo]),
-            internal=get_url(self.internal_distro.repositories[repo]))
+            upstream=get_url(self.upstream_distro.repositories.get(repo)),
+            internal=get_url(self.internal_distro.repositories.get(repo)))
 
         if diff_url:
             diff['url'] = diff_url
@@ -62,8 +62,8 @@ class CompareVerb(BaseVerb):
             return diff
 
         diff_version = build_diff(
-            upstream=get_version(self.upstream_distro.repositories[repo]),
-            internal=get_version(self.internal_distro.repositories[repo]))
+            upstream=get_version(self.upstream_distro.repositories.get(repo)),
+            internal=get_version(self.internal_distro.repositories.get(repo)))
 
         if diff_version:
             diff['version'] = diff_version
@@ -72,14 +72,14 @@ class CompareVerb(BaseVerb):
 
 
 def get_url(repo):
-    return repo.source_repository and repo.source_repository.url
+    return repo and repo.source_repository and repo.source_repository.url
 
 
 VERSION_TRIM = re.compile("-.+")
 
 
 def get_version(repo):
-    version = repo.release_repository and repo.release_repository.version
+    version = repo and repo.release_repository and repo.release_repository.version
     if version:
         version = VERSION_TRIM.sub('', version)
     return version


### PR DESCRIPTION
Previously we would compare source versions (i.e. branch name), which is not particularly useful.
Instead, we want to see a diff of any release versions that have changed. 

Also updates test runners and pinned versions.