### PR TITLE
Bump rosdistro version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
     gitpython ==2.1.14
     PyGithub ==1.43.8
     PyYaml ==3.13
-    rosdistro ==0.7.4
+    rosdistro ==0.7.5
 packages = find:
 setup_requires =
     pytest-runner


### PR DESCRIPTION
Getting the following error:

```
[2019-10-21T02:04:15.311Z] pkg_resources.ContextualVersionConflict: (rosdistro 0.7.5 (ci_tailor-distro_0.1.15/tailor-distro/.eggs/rosdistro-0.7.5-py3.6.egg), Requirement.parse('rosdistro==0.7.4'), {'tailor-distro'})
```

Tested the change on toydistro and it fixes the issue.