### PR TITLE
Use release-version instead of release-track

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -174,7 +174,7 @@ pipeline {
                   unstash(name: 'rosdistro')
 
                   sh("mirror_upstream $upstream_yaml --version $debian_version --apt-repo $params.apt_repo " +
-                     "--release-track $params.release_track --distribution $distribution --keys /gpg/*.key " +
+                     "--release-label $params.release_label --distribution $distribution --keys /gpg/*.key " +
                      "${params.force_mirror ? '--force-mirror' : ''} ${params.deploy ? '--publish' : ''}")
                 }
               } finally {
@@ -284,7 +284,7 @@ pipeline {
                   }
                   unstash(name: 'rosdistro')
                   if (params.deploy) {
-                    sh("publish_packages *.deb --release-track $params.release_track --apt-repo $params.apt_repo " +
+                    sh("publish_packages *.deb --release-label $params.release_label --apt-repo $params.apt_repo " +
                         "--keys /gpg/*.key --distribution $distribution " +
                         "${params.days_to_keep ? '--days-to-keep ' + params.days_to_keep : ''} " +
                         "${params.num_to_keep ? '--num-to-keep ' + params.num_to_keep : ''}")
@@ -312,7 +312,7 @@ pipeline {
 
           if(distribution_id) {
             withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'tailor_aws']]) {
-              cfInvalidate(distribution:distribution_id, paths:["/$params.release_track/ubuntu/dists/*"])
+              cfInvalidate(distribution:distribution_id, paths:["/$params.release_label/ubuntu/dists/*"])
             }
           }
         }

--- a/tailor_distro/__init__.py
+++ b/tailor_distro/__init__.py
@@ -47,9 +47,9 @@ def gpg_import_keys(keys: Iterable[pathlib.Path]) -> None:
         run_command(['gpg1', '--import', str(key)])
 
 
-def aptly_configure(apt_repo, release_track):
+def aptly_configure(apt_repo, release_label):
     bucket_name = get_bucket_name(apt_repo)
-    aptly_endpoint = f"s3:{bucket_name}:{release_track}/ubuntu/"
+    aptly_endpoint = f"s3:{bucket_name}:{release_label}/ubuntu/"
 
     aptly_config = {
         "gpgProvider": "internal",
@@ -72,12 +72,12 @@ def aptly_configure(apt_repo, release_track):
     return aptly_endpoint
 
 
-def deb_s3_common_args(apt_repo: str, os_name: str, os_version: str, release_track: str) -> List[str]:
+def deb_s3_common_args(apt_repo: str, os_name: str, os_version: str, release_label: str) -> List[str]:
     bucket_name = get_bucket_name(apt_repo)
     return [
         f'--bucket={bucket_name}',
         f'--origin={apt_repo}',
-        f'--prefix={release_track}/{os_name}',
+        f'--prefix={release_label}/{os_name}',
         f'--codename={os_version}',
         f'--suite={os_version}',
     ]

--- a/tailor_distro/debian_templates/Dockerfile.j2
+++ b/tailor_distro/debian_templates/Dockerfile.j2
@@ -42,7 +42,7 @@ RUN echo "AccessKeyId = $AWS_ACCESS_KEY_ID" | tee /etc/apt/s3auth.conf && \
 # Add package mirror
 # TODO(pbovbel) read this from configuration
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 142D5F1683E1528B && \
-    echo "deb [arch=amd64] s3://{{ bucket_name }}/{{ release_track }}/ubuntu {{ os_version }}-mirror main" >> /etc/apt/sources.list && \
+    echo "deb [arch=amd64] s3://{{ bucket_name }}/{{ release_label }}/ubuntu {{ os_version }}-mirror main" >> /etc/apt/sources.list && \
     apt-get update && apt-get dist-upgrade -y
 
 # Install colcon build tool

--- a/tailor_distro/mirror_upstream.py
+++ b/tailor_distro/mirror_upstream.py
@@ -75,13 +75,13 @@ def publish_mirror(snapshots: Iterable[str], version: str, architectures: Iterab
     ])
 
 
-def mirror_upstream(upstream_template: TextIO, version: str, apt_repo: str, release_track: str, distribution: str,
+def mirror_upstream(upstream_template: TextIO, version: str, apt_repo: str, release_label: str, distribution: str,
                     keys: Iterable[pathlib.Path] = [], force_mirror: bool = False, publish: bool = False):
     """Create and publish an upstream mirror.
     :param upstream_template: Template containing upstream repository operation.
     :param version: Snapshot version tag.
     :param apt_repo: Repository where to publish packages
-    :param release_track: Release track
+    :param release_label: Release label
     :param distribution: Distribution of interest.
     :param keys: (Optional) GPG keys to use while publishing.
     :param force_mirror: (Optional) Force mirror creation even if one already exists.
@@ -92,7 +92,7 @@ def mirror_upstream(upstream_template: TextIO, version: str, apt_repo: str, rele
     }
 
     # Check if mirror already exists
-    common_args = deb_s3_common_args(apt_repo, 'ubuntu', distribution + "-mirror", release_track)
+    common_args = deb_s3_common_args(apt_repo, 'ubuntu', distribution + "-mirror", release_label)
 
     packages = deb_s3_list_packages(common_args)
 
@@ -101,7 +101,7 @@ def mirror_upstream(upstream_template: TextIO, version: str, apt_repo: str, rele
         return
 
     # Configure aptly endpoint
-    endpoint = aptly_configure(apt_repo, release_track)
+    endpoint = aptly_configure(apt_repo, release_label)
 
     # Import publishing key
     gpg_import_keys(keys)
@@ -139,7 +139,7 @@ def main():
     parser.add_argument('upstream_template', type=argparse.FileType('r'))
     parser.add_argument('--version', type=str, required=True)
     parser.add_argument('--apt-repo', type=str, required=True)
-    parser.add_argument('--release-track', type=str, required=True)
+    parser.add_argument('--release-label', type=str, required=True)
     parser.add_argument('--distribution', type=str, required=True)
     parser.add_argument('--keys', type=pathlib.Path, nargs='+')
     parser.add_argument('--force-mirror', action='store_true')

--- a/tailor_distro/publish_packages.py
+++ b/tailor_distro/publish_packages.py
@@ -51,13 +51,13 @@ def build_deletion_list(packages: Iterable[PackageEntry], distribution: str,
     return delete_packages
 
 
-def publish_packages(packages: Iterable[pathlib.Path], release_track: str, apt_repo: str, distribution: str,
+def publish_packages(packages: Iterable[pathlib.Path], release_label: str, apt_repo: str, distribution: str,
                      keys: Iterable[pathlib.Path] = [], days_to_keep: int = None, num_to_keep: int = None) -> None:
-    """Publish packages in a release track to and endpoint using aptly. Optionally provided are GPG keys to use for
+    """Publish packages in a release label to and endpoint using aptly. Optionally provided are GPG keys to use for
     signing, and a cleanup policy (days/number of packages to keep).
     :param packages: Package paths to publish.
-    :param release_track: Release track of apt repo to target.
-    :param apt_repo: Apt repo where to publish release track.
+    :param release_label: Release label of apt repo to target.
+    :param apt_repo: Apt repo where to publish release label.
     :param distribution: Package distribution to publish.
     :param keys: (Optional) GPG keys to use while publishing.
     :param days_to_keep: (Optional) Age in days at which old packages should be cleaned up.
@@ -66,7 +66,7 @@ def publish_packages(packages: Iterable[pathlib.Path], release_track: str, apt_r
     if keys:
         gpg_import_keys(keys)
 
-    common_args = deb_s3_common_args(apt_repo, 'ubuntu', distribution, release_track)
+    common_args = deb_s3_common_args(apt_repo, 'ubuntu', distribution, release_label)
 
     deb_s3_upload_packages(packages, 'private', common_args)
 
@@ -83,7 +83,7 @@ def publish_packages(packages: Iterable[pathlib.Path], release_track: str, apt_r
 def main():
     parser = argparse.ArgumentParser(description=publish_packages.__doc__)
     parser.add_argument('packages', type=pathlib.Path, nargs='+')
-    parser.add_argument('--release-track', type=str, required=True)
+    parser.add_argument('--release-label', type=str, required=True)
     parser.add_argument('--apt-repo', type=str, required=True)
     parser.add_argument('--distribution', type=str, required=True)
     parser.add_argument('--keys', type=pathlib.Path, nargs='+')


### PR DESCRIPTION
Second attempt at this. This time, each release_label will have it's own separated folder for mirrors, bundles, images, etc

Tested here: http://tailor.locusbots.io/blue/organizations/jenkins/ci%2Ftoydistro/detail/feature%2Fper-release-version/3/pipeline