### PR TITLE
Make sure __pycache__ and pyc don't make it into deb

### DIFF
--- a/tailor_distro/debian_templates/rules.j2
+++ b/tailor_distro/debian_templates/rules.j2
@@ -5,6 +5,7 @@
 
 export PYTHONUNBUFFERED=1
 export PYTHONDONTWRITEBYTECODE=1
+export PYTHONPYCACHEPREFIX="$HOME/.cache/cpython/"
 export RELEASE_TRACK={{ release_track }}
 export RELEASE_LABEL={{ release_label }}
 export RELEASE_STAMP={{ debian_version }}
@@ -70,4 +71,8 @@ override_dh_shlibdeps:
 override_dh_installdeb:
 	# Fixup absolute and relative paths for installation target into /opt, don't touch .so libs
 	find . -type f ! -name '*.so' -exec sed -ri "s|($(CURDIR)/)?debian/tmp/opt|/opt|g" {} ";" && \
+	
+	# Python 3.8 now seems to write .pyc files even though PYTHONDONTWRITEBYTECODE is set, and this breaks certain modules
+	find . -name '*.pyc' -delete && \
+	
 	dh_installdeb


### PR DESCRIPTION
This was breaking certain ROS2 modules for me after our move to focal