### PR TITLE
Update release process

### DIFF
--- a/tailor_distro/manage/base.py
+++ b/tailor_distro/manage/base.py
@@ -24,7 +24,7 @@ def get_github_client():
 
 def insert_auth_token(url, token):
     parts = urlsplit(url)
-    parts._replace(netloc=token + '@' + parts.netloc)
+    parts = parts._replace(netloc=token + '@' + parts.netloc)
     return urlunsplit(parts)
 
 


### PR DESCRIPTION
This PR includes:

* update the release verb to match the new process, which doesn't tag the repos on the first release, since it's a candidate, but once the desired release branch exists on the repo, it will tag the release.
* Add `--dry-run` argument for testing
* fixes issue with _replace not replacing in place

I've tested this on my machine and works as expected.

