### PR TITLE
Install xz for mirror creation

### DIFF
--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   python3-wheel \
   git \
   ruby \
-  ruby-bundler
+  ruby-bundler \
+  xz-utils
 
 # Install aptly for managing mirror debs
 RUN echo "deb http://repo.aptly.info/ squeeze main" >> /etc/apt/sources.list && \


### PR DESCRIPTION
Aptly is currently throwing errors due to xz not being available