### PR TITLE
Treat underlay packages as peers to allow rosdep to work

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     Jinja2 ==2.10.1
     gitpython ==2.1.15
     PyGithub ==1.43.8
-    PyYaml ==3.13
+    PyYaml ==6.0
     rosdistro ==0.7.5
 packages = find:
 setup_requires =

--- a/tailor_distro/create_recipes.py
+++ b/tailor_distro/create_recipes.py
@@ -41,7 +41,6 @@ def create_recipes(recipes: Mapping[str, Any], recipes_dir: pathlib.Path, releas
                 recipe_path.parent.mkdir(parents=True, exist_ok=True)
 
                 recipe = nested_update(recipes['common'], recipe_options)
-
                 recipe = dict(
                     **recipe,
                     flavour=flavour,
@@ -53,10 +52,10 @@ def create_recipes(recipes: Mapping[str, Any], recipes_dir: pathlib.Path, releas
                     debian_version=debian_version,
                 )
                 click.echo(f"Writing {recipe_path} ...", err=True)
-                recipe_path.write_text(yaml.dump(recipe))
+                recipe_path.write_text(yaml.dump(recipe, sort_keys=False))
                 output_recipes[recipe_label] = str(recipe_path)
 
-    print(yaml.dump(output_recipes))
+    print(yaml.dump(output_recipes, sort_keys=False))
 
 
 def main():

--- a/tailor_distro/generate_bundle_templates.py
+++ b/tailor_distro/generate_bundle_templates.py
@@ -10,7 +10,7 @@ import sys
 
 from . import debian_templates, YamlLoadAction, SCHEME_S3
 
-from typing import Iterable, List, Mapping, MutableMapping, MutableSet, Callable, Any, Tuple
+from typing import Iterable, List, Mapping, MutableMapping, MutableSet, Callable, Any, Tuple, Dict, Set
 
 from bloom.generators.debian.generator import format_depends
 from bloom.generators.common import resolve_dependencies
@@ -29,7 +29,7 @@ def get_debian_build_depends(package: Package):
     return {d for d in deps if d.evaluated_condition}
 
 
-def get_dependencies(packages: Mapping[str, Package],
+def get_dependencies(packages: Mapping[str, Package], peer_packages: Set[str],
                      dependecy_getter: Callable[[Package], Iterable[Dependency]],
                      os_name: str, os_version: str) -> Iterable[str]:
     """Get resolved dependencies from a set of packages"""
@@ -43,7 +43,7 @@ def get_dependencies(packages: Mapping[str, Package],
             depends |= new_depends
             resolved_depends.update(resolve_dependencies(
                 new_depends,
-                peer_packages=packages.keys(),
+                peer_packages=peer_packages,
                 os_name=os_name,
                 os_version=os_version,
                 fallback_resolver=lambda key, peers: []
@@ -130,16 +130,22 @@ def generate_bundle_template(recipe: Mapping[str, Any], src_dir: pathlib.Path, t
     """
     build_depends: List[str] = []
     run_depends: List[str] = []
+    peer_packages: Dict[str, Set[str]] = {}
 
     for distro_name, distro_options in recipe['distributions'].items():
         click.echo(f"Building templates for rosdistro {distro_name} ...", err=True)
         packages = get_packages_in_workspace(src_dir / distro_name, distro_options.get('root_packages', None))
+        peer_packages[distro_name] = packages
+
+        for underlay in distro_options['underlays']:
+            peer_packages[distro_name] |= peer_packages[underlay]
+
         build_depends += get_dependencies(
-            packages, get_debian_build_depends, recipe['os_name'],
+            packages, peer_packages[distro_name], get_debian_build_depends, recipe['os_name'],
             recipe['os_version']
         )
         run_depends += get_dependencies(
-            packages, get_debian_depends, recipe['os_name'], recipe['os_version'])
+            packages, peer_packages[distro_name], get_debian_depends, recipe['os_name'], recipe['os_version'])
 
     build_depends += recipe['default_build_depends']
 

--- a/tailor_distro/generate_bundle_templates.py
+++ b/tailor_distro/generate_bundle_templates.py
@@ -135,9 +135,9 @@ def generate_bundle_template(recipe: Mapping[str, Any], src_dir: pathlib.Path, t
     for distro_name, distro_options in recipe['distributions'].items():
         click.echo(f"Building templates for rosdistro {distro_name} ...", err=True)
         packages = get_packages_in_workspace(src_dir / distro_name, distro_options.get('root_packages', None))
-        peer_packages[distro_name] = packages
+        peer_packages[distro_name] = packages.keys()
 
-        for underlay in distro_options['underlays']:
+        for underlay in distro_options.get('underlays', []):
             peer_packages[distro_name] |= peer_packages[underlay]
 
         build_depends += get_dependencies(

--- a/tailor_distro/generate_bundle_templates.py
+++ b/tailor_distro/generate_bundle_templates.py
@@ -24,7 +24,7 @@ def get_debian_depends(package: Package):
 
 
 def get_debian_build_depends(package: Package):
-    deps = package.build_depends + package.doc_depends + package.test_depends + package.buildtool_depends
+    deps = package.build_depends + package.doc_depends + package.buildtool_depends
     deps += package.build_export_depends + package.buildtool_export_depends
     return {d for d in deps if d.evaluated_condition}
 

--- a/tailor_distro/manage/pin.py
+++ b/tailor_distro/manage/pin.py
@@ -90,4 +90,4 @@ class PinVerb(BaseVerb):
             # TODO(pbovbel) store name of pinner?
             data.status_description = f"Pinned {age} commits behind {source_branch} on {datetime.datetime.now()}"
 
-        self.rosdistro_repo.write_internal_distro('Pinning {}'.format(', '.join(actions)))
+            self.rosdistro_repo.write_internal_distro('Pinning {}'.format(', '.join(actions)))


### PR DESCRIPTION
This allows having a package in the bridge distribution to declare dependencies on packages in underlays - though this isn't full-featured enough to cause those packages to be pulled into the build.