### PR TITLE
Don't muck up .so.x libraries

### DIFF
--- a/tailor_distro/debian_templates/rules.j2
+++ b/tailor_distro/debian_templates/rules.j2
@@ -70,6 +70,6 @@ override_dh_shlibdeps:
 
 override_dh_installdeb:
 	# Fixup absolute and relative paths for installation target into /opt, don't touch .so libs
-	find . -type f ! -name '*.so' -exec sed -ri "s|($(CURDIR)/)?debian/tmp/opt|/opt|g" {} ";" && \
+	find . -type f ! -name '*.so*' -exec sed -ri "s|($(CURDIR)/)?debian/tmp/opt|/opt|g" {} ";" && \
 	find . -name '*.pyc' -delete && \
 	dh_installdeb


### PR DESCRIPTION
This was corrupting cyclone, which is our first library that builds .so.0.0 type artifacts