### PR TITLE
Adding CCACHE_DEBUG to Docker Environment

### DIFF
--- a/tailor_distro/debian_templates/Dockerfile.j2
+++ b/tailor_distro/debian_templates/Dockerfile.j2
@@ -19,9 +19,13 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 
 # Configure ccache
+
 RUN apt-get update && apt-get install --no-install-recommends -y ccache && \
     ccache -M 5G && \
     ccache --set-config=cache_dir=/ccache
+
+# Enable CCACHE_DEBUG 
+ENV CCACHE_DEBUG 1
 
 # Install apt s3 support
 RUN apt-get update && apt-get install --no-install-recommends -y \


### PR DESCRIPTION
The following change allows to enable ccache debug value to the environment to the docker container. 
