### PR TITLE
Don't touch executable files RST-6108

### DIFF
--- a/tailor_distro/debian_templates/rules.j2
+++ b/tailor_distro/debian_templates/rules.j2
@@ -71,6 +71,6 @@ override_dh_shlibdeps:
 
 override_dh_installdeb:
 	# Fixup absolute and relative paths for installation target into /opt, don't touch .so libs
-	find . -type f ! -name '*.so*' -exec grep -I -q . {} \; -print0 | xargs -0 sed -ri "s|($(CURDIR)/)?debian/tmp/opt|/opt|g" && \
+	find . -type f -exec grep -I -q . {} \; -print0 | xargs -0 sed -ri "s|($(CURDIR)/)?debian/tmp/opt|/opt|g" && \
 	find . -name '*.pyc' -delete && \
 	dh_installdeb

--- a/tailor_distro/debian_templates/rules.j2
+++ b/tailor_distro/debian_templates/rules.j2
@@ -71,6 +71,6 @@ override_dh_shlibdeps:
 
 override_dh_installdeb:
 	# Fixup absolute and relative paths for installation target into /opt, don't touch .so libs
-	find . -type f ! -name '*.so*' -exec sed -ri "s|($(CURDIR)/)?debian/tmp/opt|/opt|g" {} ";" && \
+	find . -type f ! -name '*.so*' -exec grep -I -q . {} \; -print0 | xargs -0 sed -ri "s|($(CURDIR)/)?debian/tmp/opt|/opt|g" && \
 	find . -name '*.pyc' -delete && \
 	dh_installdeb


### PR DESCRIPTION
Found a better way to exclude binary executables. I've created a feature branch and tested the generated bundle. I confirm that rviz2 works instead of throwing a segfault and rosrun (which is a python exec) is ignored as expected.

This fixes RST-6108