### PR TITLE
Add required Region to s3-apt config

### DIFF
--- a/tailor_distro/debian_templates/Dockerfile.j2
+++ b/tailor_distro/debian_templates/Dockerfile.j2
@@ -31,7 +31,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # Create auth config file for accesing s3 via apt
 RUN echo "AccessKeyId = $AWS_ACCESS_KEY_ID" | tee /etc/apt/s3auth.conf && \
     echo "SecretAccessKey = $AWS_SECRET_ACCESS_KEY" | tee -a /etc/apt/s3auth.conf && \
-    echo "Token = ''" | tee -a /etc/apt/s3auth.conf
+    echo "Token = ''" | tee -a /etc/apt/s3auth.conf && \
+    echo "Region = '{{ bucket_region }}'" | tee -a /etc/apt/s3auth.conf
 
 # Add package mirror
 # TODO(pbovbel) read this from configuration

--- a/tailor_distro/generate_bundle_templates.py
+++ b/tailor_distro/generate_bundle_templates.py
@@ -157,6 +157,7 @@ def generate_bundle_template(recipe: Mapping[str, Any], src_dir: pathlib.Path, t
         run_depends=sorted(run_depends),
         debian_name=debian_name,
         bucket_name=recipe['apt_repo'][len(SCHEME_S3):],
+        bucket_region=recipe.get('apt_region', 'us-east-1'),
         **recipe
     )
 


### PR DESCRIPTION
`apt-transport-s3` fails if the `Region` isn't set on the config file