### PR TITLE
Updating to ensure mapping from collections.abc

### DIFF
--- a/tailor_distro/create_recipes.py
+++ b/tailor_distro/create_recipes.py
@@ -16,7 +16,7 @@ from . import YamlLoadAction
 def nested_update(d, u):
     d = deepcopy(d)
     for k, v in u.items():
-        if isinstance(v, collections.Mapping):
+        if isinstance(v, collections.abc.Mapping):
             d[k] = nested_update(d.get(k, {}), v)
         else:
             d[k] = v


### PR DESCRIPTION
If we ever want to run `create_recipes` on a Jammy instance, we will need to update collections to use the abstract base class, or abc.

Source: https://docs.python.org/3/library/collections.abc.html

This fixes the following error:

```
Traceback (most recent call last):
  File "/home/locus/locus_dev/src/venv/bin/create_recipes", line 8, in <module>
    sys.exit(main())
  File "/home/locus/locus_dev/src/tailor-distro/tailor_distro/create_recipes.py", line 82, in main
    sys.exit(create_recipes(**vars(args)))
  File "/home/locus/locus_dev/src/tailor-distro/tailor_distro/create_recipes.py", line 53, in create_recipes
    recipe = nested_update(recipes['common'], recipe_options)
  File "/home/locus/locus_dev/src/tailor-distro/tailor_distro/create_recipes.py", line 19, in nested_update
    if isinstance(v, collections.Mapping):
AttributeError: module 'collections' has no attribute 'Mapping'

```