### PR TITLE
Specify CCACHE_DIR when building

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -255,13 +255,13 @@ pipeline {
                   docker.withRegistry(params.docker_registry, docker_credentials) { bundle_image.pull() }
                 }
 
-                bundle_image.inside("-v $HOME/tailor/ccache:/ccache") {
+                bundle_image.inside("-v $HOME/tailor/ccache:/ccache -e CCACHE_DIR=/ccache") {
                   unstash(name: srcStash(params.release_label))
                   unstash(name: debianStash(recipe_label))
                   sh("""
                     ccache -z
                     cd $workspace_dir && dpkg-buildpackage -uc -us -b
-                    ccache -s
+                    ccache -s -v
                   """)
                   stash(name: packageStash(recipe_label), includes: "*.deb")
                 }


### PR DESCRIPTION
When the builds are running, the ccache gets 100% misses.
```
[2024-07-17T06:55:34.334Z] + ccache -s
[2024-07-17T06:55:34.334Z] Summary:
[2024-07-17T06:55:34.334Z]   Hits:                0 /  7076 (0.00 %)
[2024-07-17T06:55:34.334Z]     Direct:            0 /  7076 (0.00 %)
[2024-07-17T06:55:34.334Z]     Preprocessed:      0 /  7076 (0.00 %)
[2024-07-17T06:55:34.334Z]   Misses:           7076
[2024-07-17T06:55:34.334Z]     Direct:         7076
[2024-07-17T06:55:34.334Z]     Preprocessed:   7076
[2024-07-17T06:55:34.334Z] Primary storage:
[2024-07-17T06:55:34.334Z]   Hits:                0 / 14151 (0.00 %)
[2024-07-17T06:55:34.334Z]   Misses:          14151
[2024-07-17T06:55:34.334Z]   Cache size (GB):  4.46 /  5.00 (89.29 %)
[2024-07-17T06:55:34.334Z]   Cleanups:           21
```

Looking at why this might be, I see that the default cache directory is `$HOME/.ccache`
> cache_dir (CCACHE_DIR): This setting specifies where ccache will keep its cached compiler outputs. It will only take effect if set in the system-wide configuration file or as an environment variable. The default is $HOME/.ccache.

https://ccache.dev/manual/3.4.1.html#_configuration_settings

Looking at the build, we do mount a volume to store the cache in, but we mount it at `/ccache` which doesn't appear to be referenced anywhere (I couldn't find it on github). This PR just explicitly sets this as an environment var before starting the build.

I also added a `-v` to the summary which prints the cache paths that were used in case this is not accurate at all.
e.g. locally it does this now
```
➜ ccache -s -v
Summary:
  Cache directory:                  /home/m2johnson/.cache/ccache
  Primary config:                   /home/m2johnson/.config/ccache/ccache.conf
  Secondary config:                 /etc/ccache.conf
  Stats updated:                    Wed Jul 17 11:14:08 2024
  Hits:                              4676 / 21851 (21.40 %)
    Direct:                           657 / 22949 (2.86 %)
    Preprocessed:                    4019 / 22282 (18.04 %)
  Misses:                           17175
    Direct:                         22292
    Preprocessed:                   18263
  Uncacheable:                       7986
Primary storage:
  Hits:                              5373 / 45886 (11.71 %)
  Misses:                           40513
  Cache size (GB):                   0.88 /  1.00 (88.05 %)
  Files:                            17118
  Cleanups:                            28
Uncacheable:
  Called for linking:                4634
  Called for preprocessing:           137
  Compilation failed:                  61
  Compiler produced empty output:    1008
  Compiler produced stdout:            19
  Could not use precompiled header:     5
  No input file:                     1493
  Preprocessing failed:                10
  Unsupported compiler option:        619
```