### PR TITLE
Test with max cache size

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -256,7 +256,8 @@ pipeline {
                 }
                 bundle_image.inside("-v $HOME/tailor/ccache:/ccache -e CCACHE_DIR=/ccache") {
                   // Invoke the Jenkins Job Cacher Plugin via the cache method. 
-                  cache(caches: [
+                  // Set the max cache size to 4GB, as S3 only allows a 5GB max upload at once
+                  cache(maxCacheSize: 4000, caches: [
                     arbitraryFileCache(path: '${HOME}/tailor/ccache', cacheName: recipe_label)
                   ]) {
                       unstash(name: srcStash(params.release_label))


### PR DESCRIPTION
This is to ensure the cache does not get too big for our packages, since AWS only allows 5GB. We can keep this at 4GB, however if we want to increase it, we can test at a later date to fine the optimal value. 