### PR TITLE
Increase from 4GB to 4.9GB, as S3 only allows for 5GB max one-time up…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -265,7 +265,7 @@ pipeline {
                 bundle_image.inside("-v $HOME/tailor/ccache:/ccache -e CCACHE_DIR=/ccache") {
                   // Invoke the Jenkins Job Cacher Plugin via the cache method.
                   // Set the max cache size to 4GB, as S3 only allows a 5GB max upload at once
-                  cache(maxCacheSize: 4000, caches: [
+                  cache(maxCacheSize: 4900, caches: [
                     arbitraryFileCache(path: '${HOME}/tailor/ccache', cacheName: recipe_label)
                   ]) {
                       unstash(name: srcStash(params.release_label))


### PR DESCRIPTION
AWS S3 only allows for 5GB max one-time upload, and this change allows for at least a 100MB buffer incase AWS does a different calculation on upload size. 
