### PR TITLE
Match the ccache size to jenkins cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -262,7 +262,9 @@ pipeline {
                 retry(params.retries as Integer) {
                   docker.withRegistry(params.docker_registry, docker_credentials) { bundle_image.pull() }
                 }
-                bundle_image.inside("-v $HOME/tailor/ccache:/ccache -e CCACHE_DIR=/ccache") {
+                // The cache sizes need to be consistent. 
+                // If the ccache gets larger than the Jenkins size below it will be discarded.
+                bundle_image.inside("-v $HOME/tailor/ccache:/ccache -e CCACHE_DIR=/ccache -e CCACHE_MAXSIZE=4900M") {
                   // Invoke the Jenkins Job Cacher Plugin via the cache method.
                   // Set the max cache size to 4GB, as S3 only allows a 5GB max upload at once
                   cache(maxCacheSize: 4900, caches: [


### PR DESCRIPTION
ccache has a default size of 5GB and will keep the cache below that  value. If the Jenkins cache is smaller (e.g. 4GB) then the cache will be discarded any time it goes above 4GB. Instead we can decrease the ccache size so that the cache should always fit.

Follow up to https://github.com/locusrobotics/tailor-distro/pull/96