### PR TITLE
Run tailor-distro on Noble

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
               "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY .")
           }
           parent_image.inside() {
-            sh('pip3 install -e tailor-distro')
+            sh('pip3 install -e tailor-distro --break-system-packages')
           }
           docker.withRegistry(params.docker_registry, docker_credentials) {
             parent_image.push()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -275,7 +275,7 @@ pipeline {
                       unstash(name: debianStash(recipe_label))
                       sh("""
                         ccache -z
-                        cd $workspace_dir && dpkg-buildpackage -uc -us -b
+                        cd $workspace_dir && dpkg-buildpackage -uc -us -b --jobs=auto
                         ccache -s -v
                       """)
                       stash(name: packageStash(recipe_label), includes: "*.deb")

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -37,13 +37,14 @@ RUN echo "deb http://repo.aptly.info/ squeeze main" >> /etc/apt/sources.list && 
 RUN git clone https://github.com/locusrobotics/deb-s3.git && \
     cd deb-s3 && bundle update --bundler && bundle install && ln -sf $(pwd)/bin/deb-s3 /usr/local/bin/deb-s3
 
+# Build and install rosdistro
+COPY tailor-distro tailor-distro
+RUN pip3 install -e tailor-distro --break-system-packages
+
 # Inject the rosdep definitions from source
 RUN if [[ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]] ; then rosdep init ; fi
 RUN echo "yaml file:///etc/ros/rosdep/rosdep.yaml" > /etc/ros/rosdep/sources.list.d/10-tailor.list
 COPY rosdistro/rosdep/rosdep.yaml /etc/ros/rosdep/rosdep.yaml
-
-COPY tailor-distro tailor-distro
-RUN pip3 install -e tailor-distro
 
 RUN groupadd -r tailor && useradd -ms /bin/bash -g tailor -G sudo tailor
 USER tailor

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:noble
 
 LABEL tailor="environment"
 

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -46,7 +46,10 @@ RUN if [[ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]] ; then rosdep i
 RUN echo "yaml file:///etc/ros/rosdep/rosdep.yaml" > /etc/ros/rosdep/sources.list.d/10-tailor.list
 COPY rosdistro/rosdep/rosdep.yaml /etc/ros/rosdep/rosdep.yaml
 
-RUN groupadd -r tailor && useradd -ms /bin/bash -g tailor -G sudo tailor
+RUN usermod -md /home/tailor -s /bin/bash -l tailor ubuntu
+RUN groupmod -n tailor ubuntu
+RUN echo "tailor:tailor" | chpasswd
+RUN echo "tailor ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
 USER tailor
 
 RUN mkdir -p /home/tailor && \

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -36,7 +36,7 @@ RUN echo "deb http://repo.aptly.info/ squeeze main" >> /etc/apt/sources.list && 
     apt-get update && apt-get install --no-install-recommends -y aptly
 
 # Install locusrobotics deb-s3 fork for managing bundle debs
-RUN git clone https://github.com/locusrobotics/deb-s3.git && \
+RUN git clone -b rebase-new-deb-s3 https://github.com/locusrobotics/deb-s3.git && \
     cd deb-s3 && bundle update --bundler && bundle install && ln -sf $(pwd)/bin/deb-s3 /usr/local/bin/deb-s3
 
 # Build and install rosdistro

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -19,6 +19,8 @@ ENV LANG en_US.UTF-8
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
   python3-rosdep \
+  bzip2 \
+  gnupg1 \
   python3-dev \
   python3-pip \
   python3-setuptools \

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -18,7 +18,6 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-  python3-rosdep \
   bzip2 \
   gnupg1 \
   python3-dev \

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -31,9 +31,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   xz-utils
 
 # Install aptly for managing mirror debs
-RUN echo "deb http://repo.aptly.info/ squeeze main" >> /etc/apt/sources.list && \
-    curl --silent https://www.aptly.info/pubkey.txt | apt-key add - && \
-    apt-get update && apt-get install --no-install-recommends -y aptly
+ADD https://github.com/aptly-dev/aptly/releases/download/v1.5.0/aptly_1.5.0_linux_amd64.tar.gz /tmp
+RUN tar xzf /tmp/aptly_1.5.0_linux_amd64.tar.gz --strip-components 1 -C /usr/local/bin
 
 # Install locusrobotics deb-s3 fork for managing bundle debs
 RUN git clone -b rebase-new-deb-s3 https://github.com/locusrobotics/deb-s3.git && \

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,23 +13,23 @@ description = Build bundles of ROS distributions.
 long_description = file: README.md
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.10
 install_requires =
-    bloom ==0.11.2
-    catkin_pkg ==0.5.2
-    Click ==8.1.3
-    Jinja2 ==3.1.2
-    gitpython ==3.1.31
-    PyGithub ==2.6.1
-    PyYaml ==6.0
-    rosdistro ==0.9.0
+    bloom ==0.12.0
+    catkin_pkg ==1.0.0
+    Click ==8.1.7
+    Jinja2 ==3.1.4
+    gitpython ==3.1.43
+    PyGithub ==2.5.0
+    PyYaml ==6.0.2
+    rosdistro ==1.0.1
 packages = find:
 setup_requires =
     pytest-runner ==5.1
 tests_require =
-    pytest ==5.1.3
-    pytest-mypy ==0.4.1
-    pytest-flake8 ==1.0.4
+    pytest ==8.4.3
+    pytest-mypy ==0.10.3
+    pytest-flake8 ==1.3.0
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     PyGithub ==2.5.0
     PyYaml ==6.0.2
     rosdistro ==1.0.1
+    rosdep ==0.25.1
 packages = find:
 setup_requires =
     pytest-runner ==5.1

--- a/tailor_distro/debian_templates/rules.j2
+++ b/tailor_distro/debian_templates/rules.j2
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@
+	dh $@ --parallel
 
 export PYTHONUNBUFFERED=1
 export PYTHONDONTWRITEBYTECODE=1
@@ -77,3 +77,6 @@ override_dh_installdeb:
 	find . -type f -exec grep -I -q . {} \; -print0 | xargs -0 sed -ri "s|($(CURDIR)/)?debian/tmp/opt|/opt|g" && \
 	find . -name '*.pyc' -delete && \
 	dh_installdeb
+
+overide_dh_builddeb:
+	dh_builddeb -- -Zzstd --threads-max=32


### PR DESCRIPTION
These are the required changes to be able to run tailor-distro on Noble.

These _should_ work with the current config of the builfdarm, but I still need to confirm with more testing. The only changed I can't change atm is that we need to use the default branch for https://github.com/locusrobotics/deb-s3.git instead of the `rebase-new-deb-s3` changed in this PR, but I can't since that will mess with the current builfarm config.

I'll test a full build with these changes with the current hotdog and make the changes accordingly if that works. So marking this as a draft for now.