### PR TITLE
Merge in different Mirror usage with Tailor-Distro

### DIFF
--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -13,7 +13,7 @@ ENV AWS_SECRET_ACCESS_KEY ${AWS_SECRET_ACCESS_KEY}
 ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONUNBUFFERED 1
 
-RUN sed -i 's/archive.ubuntu.com/us-east-1.ec2. &/g' /etc/apt/sources.list
+RUN sed -i 's/archive.ubuntu.com/us-east-1.ec2.&/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install --no-install-recommends -y locales curl gnupg1 sudo
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -13,6 +13,7 @@ ENV AWS_SECRET_ACCESS_KEY ${AWS_SECRET_ACCESS_KEY}
 ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONUNBUFFERED 1
 
+RUN sed -i 's/archive.ubuntu.com/us-east-1.ec2. &/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install --no-install-recommends -y locales curl gnupg1 sudo
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8

--- a/tailor_distro/debian_templates/Dockerfile.j2
+++ b/tailor_distro/debian_templates/Dockerfile.j2
@@ -13,6 +13,7 @@ ENV AWS_SECRET_ACCESS_KEY ${AWS_SECRET_ACCESS_KEY}
 ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONUNBUFFERED 1
 
+RUN sed -i 's/archive.ubuntu.com/us-east-1.ec2. &/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install --no-install-recommends -y \
     locales curl gnupg sudo ccache software-properties-common expect
 RUN locale-gen en_US.UTF-8

--- a/tailor_distro/debian_templates/Dockerfile.j2
+++ b/tailor_distro/debian_templates/Dockerfile.j2
@@ -13,7 +13,7 @@ ENV AWS_SECRET_ACCESS_KEY ${AWS_SECRET_ACCESS_KEY}
 ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONUNBUFFERED 1
 
-RUN sed -i 's/archive.ubuntu.com/us-east-1.ec2. &/g' /etc/apt/sources.list
+RUN sed -i 's/archive.ubuntu.com/us-east-1.ec2.&/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install --no-install-recommends -y \
     locales curl gnupg sudo ccache software-properties-common expect
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
Adding support for tailor-distro to use a different mirror. This has been running on the build farm currently, and things look to be okay, so this PR is to make things permanent. 