### PR TITLE
Don't use --jobs as it breaks jammy builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -284,7 +284,7 @@ pipeline {
                       unstash(name: debianStash(recipe_label))
                       sh("""
                         ccache -z
-                        cd $workspace_dir && dpkg-buildpackage -uc -us -b --jobs=auto
+                        cd $workspace_dir && dpkg-buildpackage -uc -us -b
                         ccache -s -v
                       """)
                       stash(name: packageStash(recipe_label), includes: "*.deb")


### PR DESCRIPTION
Turns out we don't really need this and having it makes jammy build using -j1, which makes it take longer. Tested here http://tailor.locusbots.io/blue/organizations/jenkins/ci%2Ftailor-distro/detail/ubuntu24/369/pipeline