### PR TITLE
Use docker cache while still updating apt packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,8 +100,7 @@ pipeline {
               parent_image = docker.build(parent_image_label,
                 "-f tailor-distro/environment/Dockerfile --cache-from ${parent_image_label} " +
                 "--build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
-                "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY " +
-                "--build-arg BUILDKIT_INLINE_CACHE=1 .")
+                "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY .")
             }
             parent_image.inside() {
               sh('pip3 install -e tailor-distro --break-system-packages')
@@ -121,245 +120,245 @@ pipeline {
       }
     }
 
-    // stage("Setup recipes and pull sources") {
-    //   agent any
-    //   steps {
-    //     script {
-    //       def parent_image = docker.image(parentImage(params.release_label, params.docker_registry))
-    //       retry(params.retries as Integer) {
-    //         docker.withRegistry(params.docker_registry, docker_credentials) { parent_image.pull() }
-    //       }
+    stage("Setup recipes and pull sources") {
+      agent any
+      steps {
+        script {
+          def parent_image = docker.image(parentImage(params.release_label, params.docker_registry))
+          retry(params.retries as Integer) {
+            docker.withRegistry(params.docker_registry, docker_credentials) { parent_image.pull() }
+          }
 
-    //       parent_image.inside() {
-    //         unstash(name: 'rosdistro')
-    //         // Generate recipe configuration files
-    //         def recipe_yaml = sh(
-    //           script: "create_recipes --recipes $recipes_yaml --recipes-dir $recipes_dir " +
-    //                   "--release-track $params.release_track --release-label $params.release_label --debian-version $params.timestamp",
-    //           returnStdout: true).trim()
+          parent_image.inside() {
+            unstash(name: 'rosdistro')
+            // Generate recipe configuration files
+            def recipe_yaml = sh(
+              script: "create_recipes --recipes $recipes_yaml --recipes-dir $recipes_dir " +
+                      "--release-track $params.release_track --release-label $params.release_label --debian-version $params.timestamp",
+              returnStdout: true).trim()
 
-    //         // Script returns a mapping of recipe labels and paths
-    //         recipes = readYaml(text: recipe_yaml)
+            // Script returns a mapping of recipe labels and paths
+            recipes = readYaml(text: recipe_yaml)
 
-    //         distributions = readYaml(file: recipes_yaml)['os'].collect {
-    //           os, distribution -> distribution }.flatten()
+            distributions = readYaml(file: recipes_yaml)['os'].collect {
+              os, distribution -> distribution }.flatten()
 
-    //         // Stash each recipe configuration individually for parallel build nodes
-    //         recipes.each { recipe_label, recipe_path ->
-    //           stash(name: recipeStash(recipe_label), includes: recipe_path)
-    //         }
+            // Stash each recipe configuration individually for parallel build nodes
+            recipes.each { recipe_label, recipe_path ->
+              stash(name: recipeStash(recipe_label), includes: recipe_path)
+            }
 
-    //         // Pull down distribution sources
-    //         withCredentials([string(credentialsId: 'tailor_github', variable: 'GITHUB_TOKEN')]) {
-    //           sh "pull_distro_repositories --src-dir $src_dir --github-key $GITHUB_TOKEN " +
-    //             "--recipes $recipes_yaml  --rosdistro-index $rosdistro_index --clean"
-    //           stash(name: srcStash(params.release_label), includes: "$src_dir/")
-    //         }
-    //       }
-    //     }
-    //   }
-    //   post {
-    //     always {
-    //       archiveArtifacts(artifacts: "$recipes_dir/*.yaml")
-    //     }
-    //     cleanup {
-    //       library("tailor-meta@${params.tailor_meta}")
-    //       cleanDocker()
-    //       deleteDir()
-    //     }
-    //   }
-    // }
+            // Pull down distribution sources
+            withCredentials([string(credentialsId: 'tailor_github', variable: 'GITHUB_TOKEN')]) {
+              sh "pull_distro_repositories --src-dir $src_dir --github-key $GITHUB_TOKEN " +
+                "--recipes $recipes_yaml  --rosdistro-index $rosdistro_index --clean"
+              stash(name: srcStash(params.release_label), includes: "$src_dir/")
+            }
+          }
+        }
+      }
+      post {
+        always {
+          archiveArtifacts(artifacts: "$recipes_dir/*.yaml")
+        }
+        cleanup {
+          library("tailor-meta@${params.tailor_meta}")
+          cleanDocker()
+          deleteDir()
+        }
+      }
+    }
 
 
-    // stage("Create upstream mirrors") {
-    //   agent none
-    //   steps {
-    //     script {
-    //       def jobs = distributions.collectEntries { distribution ->
-    //         [distribution, { node {
-    //           try {
-    //             def parent_image = docker.image(parentImage(params.release_label, params.docker_registry))
-    //             retry(params.retries as Integer) {
-    //               docker.withRegistry(params.docker_registry, docker_credentials) {
-    //                 parent_image.pull()
-    //               }
-    //             }
-    //             parent_image.inside("-v $HOME/tailor/gpg:/gpg") {
-    //               unstash(name: 'rosdistro')
+    stage("Create upstream mirrors") {
+      agent none
+      steps {
+        script {
+          def jobs = distributions.collectEntries { distribution ->
+            [distribution, { node {
+              try {
+                def parent_image = docker.image(parentImage(params.release_label, params.docker_registry))
+                retry(params.retries as Integer) {
+                  docker.withRegistry(params.docker_registry, docker_credentials) {
+                    parent_image.pull()
+                  }
+                }
+                parent_image.inside("-v $HOME/tailor/gpg:/gpg") {
+                  unstash(name: 'rosdistro')
 
-    //               sh("mirror_upstream $upstream_yaml --version $params.timestamp --apt-repo $params.apt_repo " +
-    //                  "--release-label $params.release_label --distribution $distribution --keys /gpg/*.key " +
-    //                  "${params.force_mirror ? '--force-mirror' : ''} ${params.deploy ? '--publish' : ''}")
-    //             }
-    //           } finally {
-    //               library("tailor-meta@${params.tailor_meta}")
-    //               cleanDocker()
-    //               try {
-    //                 deleteDir()
-    //               } catch (e) {
-    //                 println e
-    //               }
-    //           }
-    //         }}]
-    //       }
-    //       parallel(jobs)
-    //     }
-    //   }
-    // }
+                  sh("mirror_upstream $upstream_yaml --version $params.timestamp --apt-repo $params.apt_repo " +
+                     "--release-label $params.release_label --distribution $distribution --keys /gpg/*.key " +
+                     "${params.force_mirror ? '--force-mirror' : ''} ${params.deploy ? '--publish' : ''}")
+                }
+              } finally {
+                  library("tailor-meta@${params.tailor_meta}")
+                  cleanDocker()
+                  try {
+                    deleteDir()
+                  } catch (e) {
+                    println e
+                  }
+              }
+            }}]
+          }
+          parallel(jobs)
+        }
+      }
+    }
 
-    // stage("Create packaging environment") {
-    //   agent none
-    //   steps {
-    //     script {
-    //       def jobs = recipes.collectEntries { recipe_label, recipe_path ->
-    //         [recipe_label, { node {
-    //           try {
-    //             def parent_image = docker.image(parentImage(params.release_label, params.docker_registry))
-    //             retry(params.retries as Integer) {
-    //               docker.withRegistry(params.docker_registry, docker_credentials) { parent_image.pull() }
+    stage("Create packaging environment") {
+      agent none
+      steps {
+        script {
+          def jobs = recipes.collectEntries { recipe_label, recipe_path ->
+            [recipe_label, { node {
+              try {
+                def parent_image = docker.image(parentImage(params.release_label, params.docker_registry))
+                retry(params.retries as Integer) {
+                  docker.withRegistry(params.docker_registry, docker_credentials) { parent_image.pull() }
 
-    //               parent_image.inside() {
-    //                 unstash(name: srcStash(params.release_label))
-    //                 unstash(name: recipeStash(recipe_label))
-    //                 sh "ROS_PYTHON_VERSION=$params.python_version generate_bundle_templates --src-dir $src_dir --template-dir $debian_dir --recipe $recipe_path"
-    //                 stash(name: debianStash(recipe_label), includes: "$debian_dir/")
-    //               }
-    //             }
+                  parent_image.inside() {
+                    unstash(name: srcStash(params.release_label))
+                    unstash(name: recipeStash(recipe_label))
+                    sh "ROS_PYTHON_VERSION=$params.python_version generate_bundle_templates --src-dir $src_dir --template-dir $debian_dir --recipe $recipe_path"
+                    stash(name: debianStash(recipe_label), includes: "$debian_dir/")
+                  }
+                }
 
-    //             def bundle_image = docker.image(bundleImage(recipe_label, params.docker_registry))
-    //             retry(params.retries as Integer) {
-    //               withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'tailor_aws']]) {
-    //                 bundle_image = docker.build(bundleImage(recipe_label, params.docker_registry),
-    //                   "-f $debian_dir/Dockerfile --no-cache " +
-    //                   "--build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
-    //                   "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY $workspace_dir")
-    //               }
-    //             }
+                def bundle_image = docker.image(bundleImage(recipe_label, params.docker_registry))
+                retry(params.retries as Integer) {
+                  withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'tailor_aws']]) {
+                    bundle_image = docker.build(bundleImage(recipe_label, params.docker_registry),
+                      "-f $debian_dir/Dockerfile --no-cache " +
+                      "--build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
+                      "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY $workspace_dir")
+                  }
+                }
 
-    //             retry(params.retries as Integer) {
-    //               docker.withRegistry(params.docker_registry, docker_credentials) { bundle_image.push() }
-    //             }
+                retry(params.retries as Integer) {
+                  docker.withRegistry(params.docker_registry, docker_credentials) { bundle_image.push() }
+                }
 
-    //           } finally {
-    //             // Jenkins requires all artifacts to have unique filenames
-    //             sh "find $debian_dir -type f -exec mv {} {}-$recipe_label \\; || true"
-    //             archiveArtifacts(
-    //               artifacts: "$debian_dir/rules*, $debian_dir/control*, $debian_dir/Dockerfile*", allowEmptyArchive: true)
+              } finally {
+                // Jenkins requires all artifacts to have unique filenames
+                sh "find $debian_dir -type f -exec mv {} {}-$recipe_label \\; || true"
+                archiveArtifacts(
+                  artifacts: "$debian_dir/rules*, $debian_dir/control*, $debian_dir/Dockerfile*", allowEmptyArchive: true)
 
-    //             withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'tailor_aws']]) {
-    //               s3Upload(
-    //                 bucket: params.apt_repo.replace('s3://', ''),
-    //                 path: "${params.release_label}/dependencies",
-    //                 includePathPattern: 'control*',
-    //                 workingDir: "${debian_dir}",
-    //               )
-    //             }
-    //             library("tailor-meta@${params.tailor_meta}")
-    //             cleanDocker()
-    //             try {
-    //               deleteDir()
-    //             } catch (e) {
-    //               println e
-    //             }
-    //           }
-    //         }}]
-    //       }
-    //       parallel(jobs)
-    //     }
-    //   }
-    // }
+                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'tailor_aws']]) {
+                  s3Upload(
+                    bucket: params.apt_repo.replace('s3://', ''),
+                    path: "${params.release_label}/dependencies",
+                    includePathPattern: 'control*',
+                    workingDir: "${debian_dir}",
+                  )
+                }
+                library("tailor-meta@${params.tailor_meta}")
+                cleanDocker()
+                try {
+                  deleteDir()
+                } catch (e) {
+                  println e
+                }
+              }
+            }}]
+          }
+          parallel(jobs)
+        }
+      }
+    }
 
-    // stage("Build and package") {
-    //   agent none
-    //   steps {
-    //     script {
-    //       def jobs = recipes.collectEntries { recipe_label, recipe_path ->
-    //         [recipe_label, { node {
-    //           try {
-    //             def bundle_image = docker.image(bundleImage(recipe_label, params.docker_registry))
-    //             retry(params.retries as Integer) {
-    //               docker.withRegistry(params.docker_registry, docker_credentials) { bundle_image.pull() }
-    //             }
-    //             bundle_image.inside("-v $HOME/tailor/ccache:/ccache -e CCACHE_DIR=/ccache") {
-    //             // The cache sizes need to be consistent.
-    //             // If the ccache gets larger than the Jenkins size below it will be discarded.
-    //             // bundle_image.inside("-v $HOME/tailor/ccache:/ccache -e CCACHE_DIR=/ccache -e CCACHE_MAXSIZE=4900M") {
-    //               // // Invoke the Jenkins Job Cacher Plugin via the cache method.
-    //               // // Set the max cache size to 4GB, as S3 only allows a 5GB max upload at once
-    //               // cache(maxCacheSize: 4900, caches: [
-    //               //  arbitraryFileCache(path: '${HOME}/tailor/ccache', cacheName: recipe_label, compressionMethod: 'TARGZ_BEST_SPEED')
-    //               // ]) {
-    //                   unstash(name: srcStash(params.release_label))
-    //                   unstash(name: debianStash(recipe_label))
-    //                   sh("""
-    //                     ccache -z
-    //                     cd $workspace_dir && dpkg-buildpackage -uc -us -b
-    //                     ccache -s -v
-    //                   """)
-    //                   stash(name: packageStash(recipe_label), includes: "*.deb")
-    //               // }
-    //             }
-    //           } finally {
-    //             // Don't archive debs - too big. Consider s3 upload?
-    //             // archiveArtifacts(artifacts: "*.deb", allowEmptyArchive: true)
-    //             library("tailor-meta@${params.tailor_meta}")
-    //             try {
-    //               if (fileExists(".")) {
-    //                 deleteDir()
-    //               }
-    //             } catch (e) {
-    //               println e
-    //             }
-    //             cleanDocker()
-    //           }
-    //         }}]
-    //       }
-    //       parallel(jobs)
-    //     }
-    //   }
-    // }
+    stage("Build and package") {
+      agent none
+      steps {
+        script {
+          def jobs = recipes.collectEntries { recipe_label, recipe_path ->
+            [recipe_label, { node {
+              try {
+                def bundle_image = docker.image(bundleImage(recipe_label, params.docker_registry))
+                retry(params.retries as Integer) {
+                  docker.withRegistry(params.docker_registry, docker_credentials) { bundle_image.pull() }
+                }
+                bundle_image.inside("-v $HOME/tailor/ccache:/ccache -e CCACHE_DIR=/ccache") {
+                // The cache sizes need to be consistent.
+                // If the ccache gets larger than the Jenkins size below it will be discarded.
+                // bundle_image.inside("-v $HOME/tailor/ccache:/ccache -e CCACHE_DIR=/ccache -e CCACHE_MAXSIZE=4900M") {
+                  // // Invoke the Jenkins Job Cacher Plugin via the cache method.
+                  // // Set the max cache size to 4GB, as S3 only allows a 5GB max upload at once
+                  // cache(maxCacheSize: 4900, caches: [
+                  //  arbitraryFileCache(path: '${HOME}/tailor/ccache', cacheName: recipe_label, compressionMethod: 'TARGZ_BEST_SPEED')
+                  // ]) {
+                      unstash(name: srcStash(params.release_label))
+                      unstash(name: debianStash(recipe_label))
+                      sh("""
+                        ccache -z
+                        cd $workspace_dir && dpkg-buildpackage -uc -us -b
+                        ccache -s -v
+                      """)
+                      stash(name: packageStash(recipe_label), includes: "*.deb")
+                  // }
+                }
+              } finally {
+                // Don't archive debs - too big. Consider s3 upload?
+                // archiveArtifacts(artifacts: "*.deb", allowEmptyArchive: true)
+                library("tailor-meta@${params.tailor_meta}")
+                try {
+                  if (fileExists(".")) {
+                    deleteDir()
+                  }
+                } catch (e) {
+                  println e
+                }
+                cleanDocker()
+              }
+            }}]
+          }
+          parallel(jobs)
+        }
+      }
+    }
 
-    // stage("Ship packages") {
-    //   agent none
-    //   steps {
-    //     script {
-    //       def jobs = distributions.collectEntries { distribution ->
-    //         [distribution, { node {
-    //           try {
-    //             def parent_image = docker.image(parentImage(params.release_label, params.docker_registry))
-    //             retry(params.retries as Integer) {
-    //               docker.withRegistry(params.docker_registry, docker_credentials) { parent_image.pull() }
-    //             }
+    stage("Ship packages") {
+      agent none
+      steps {
+        script {
+          def jobs = distributions.collectEntries { distribution ->
+            [distribution, { node {
+              try {
+                def parent_image = docker.image(parentImage(params.release_label, params.docker_registry))
+                retry(params.retries as Integer) {
+                  docker.withRegistry(params.docker_registry, docker_credentials) { parent_image.pull() }
+                }
 
-    //             parent_image.inside("-v $HOME/tailor/gpg:/gpg") {
-    //               recipes.each { recipe_label, recipe_path ->
-    //                 if (recipe_label.contains(distribution)) {
-    //                   unstash(name: packageStash(recipe_label))
-    //                 }
-    //               }
-    //               unstash(name: 'rosdistro')
-    //               if (params.deploy) {
-    //                 sh("publish_packages *.deb --release-label $params.release_label --apt-repo $params.apt_repo " +
-    //                     "--keys /gpg/*.key --distribution $distribution " +
-    //                     "${params.days_to_keep ? '--days-to-keep ' + params.days_to_keep : ''} " +
-    //                     "${params.num_to_keep ? '--num-to-keep ' + params.num_to_keep : ''}")
-    //               }
-    //             }
-    //           } finally {
-    //             library("tailor-meta@${params.tailor_meta}")
-    //             cleanDocker()
-    //             try {
-    //               deleteDir()
-    //             } catch (e) {
-    //               println e
-    //             }
-    //           }
-    //         }}]
-    //       }
-    //       parallel(jobs)
-    //     }
-    //   }
-    // }
+                parent_image.inside("-v $HOME/tailor/gpg:/gpg") {
+                  recipes.each { recipe_label, recipe_path ->
+                    if (recipe_label.contains(distribution)) {
+                      unstash(name: packageStash(recipe_label))
+                    }
+                  }
+                  unstash(name: 'rosdistro')
+                  if (params.deploy) {
+                    sh("publish_packages *.deb --release-label $params.release_label --apt-repo $params.apt_repo " +
+                        "--keys /gpg/*.key --distribution $distribution " +
+                        "${params.days_to_keep ? '--days-to-keep ' + params.days_to_keep : ''} " +
+                        "${params.num_to_keep ? '--num-to-keep ' + params.num_to_keep : ''}")
+                  }
+                }
+              } finally {
+                library("tailor-meta@${params.tailor_meta}")
+                cleanDocker()
+                try {
+                  deleteDir()
+                } catch (e) {
+                  println e
+                }
+              }
+            }}]
+          }
+          parallel(jobs)
+        }
+      }
+    }
 
     stage("Invalidate CDN's cache") {
       agent any

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,18 +88,27 @@ pipeline {
             echo("Unable to pull ${parent_image_label} as a build cache")
           }
 
-          withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'tailor_aws']]) {
-            unstash(name: 'rosdistro')
-            parent_image = docker.build(parent_image_label,
-              "-f tailor-distro/environment/Dockerfile --cache-from ${parent_image_label} " +
-              "--build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
-              "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY .")
-          }
-          parent_image.inside() {
-            sh('pip3 install -e tailor-distro --break-system-packages')
-          }
-          docker.withRegistry(params.docker_registry, docker_credentials) {
-            parent_image.push()
+          withEnv(['DOCKER_BUILDKIT=1']) {
+            try {
+              docker.withRegistry(params.docker_registry, docker_credentials) {parent_image.pull()}
+            } catch (all) {
+              echo("Unable to pull ${parent_image_label} as a build cache")
+            }
+
+            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'tailor_aws']]) {
+              unstash(name: 'rosdistro')
+              parent_image = docker.build(parent_image_label,
+                "-f tailor-distro/environment/Dockerfile --cache-from ${parent_image_label} " +
+                "--build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
+                "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY " +
+                "--build-arg BUILDKIT_INLINE_CACHE=1 .")
+            }
+            parent_image.inside() {
+              sh('pip3 install -e tailor-distro --break-system-packages')
+            }
+            docker.withRegistry(params.docker_registry, docker_credentials) {
+              parent_image.push()
+            }
           }
         }
       }
@@ -112,245 +121,245 @@ pipeline {
       }
     }
 
-    stage("Setup recipes and pull sources") {
-      agent any
-      steps {
-        script {
-          def parent_image = docker.image(parentImage(params.release_label, params.docker_registry))
-          retry(params.retries as Integer) {
-            docker.withRegistry(params.docker_registry, docker_credentials) { parent_image.pull() }
-          }
+    // stage("Setup recipes and pull sources") {
+    //   agent any
+    //   steps {
+    //     script {
+    //       def parent_image = docker.image(parentImage(params.release_label, params.docker_registry))
+    //       retry(params.retries as Integer) {
+    //         docker.withRegistry(params.docker_registry, docker_credentials) { parent_image.pull() }
+    //       }
 
-          parent_image.inside() {
-            unstash(name: 'rosdistro')
-            // Generate recipe configuration files
-            def recipe_yaml = sh(
-              script: "create_recipes --recipes $recipes_yaml --recipes-dir $recipes_dir " +
-                      "--release-track $params.release_track --release-label $params.release_label --debian-version $params.timestamp",
-              returnStdout: true).trim()
+    //       parent_image.inside() {
+    //         unstash(name: 'rosdistro')
+    //         // Generate recipe configuration files
+    //         def recipe_yaml = sh(
+    //           script: "create_recipes --recipes $recipes_yaml --recipes-dir $recipes_dir " +
+    //                   "--release-track $params.release_track --release-label $params.release_label --debian-version $params.timestamp",
+    //           returnStdout: true).trim()
 
-            // Script returns a mapping of recipe labels and paths
-            recipes = readYaml(text: recipe_yaml)
+    //         // Script returns a mapping of recipe labels and paths
+    //         recipes = readYaml(text: recipe_yaml)
 
-            distributions = readYaml(file: recipes_yaml)['os'].collect {
-              os, distribution -> distribution }.flatten()
+    //         distributions = readYaml(file: recipes_yaml)['os'].collect {
+    //           os, distribution -> distribution }.flatten()
 
-            // Stash each recipe configuration individually for parallel build nodes
-            recipes.each { recipe_label, recipe_path ->
-              stash(name: recipeStash(recipe_label), includes: recipe_path)
-            }
+    //         // Stash each recipe configuration individually for parallel build nodes
+    //         recipes.each { recipe_label, recipe_path ->
+    //           stash(name: recipeStash(recipe_label), includes: recipe_path)
+    //         }
 
-            // Pull down distribution sources
-            withCredentials([string(credentialsId: 'tailor_github', variable: 'GITHUB_TOKEN')]) {
-              sh "pull_distro_repositories --src-dir $src_dir --github-key $GITHUB_TOKEN " +
-                "--recipes $recipes_yaml  --rosdistro-index $rosdistro_index --clean"
-              stash(name: srcStash(params.release_label), includes: "$src_dir/")
-            }
-          }
-        }
-      }
-      post {
-        always {
-          archiveArtifacts(artifacts: "$recipes_dir/*.yaml")
-        }
-        cleanup {
-          library("tailor-meta@${params.tailor_meta}")
-          cleanDocker()
-          deleteDir()
-        }
-      }
-    }
+    //         // Pull down distribution sources
+    //         withCredentials([string(credentialsId: 'tailor_github', variable: 'GITHUB_TOKEN')]) {
+    //           sh "pull_distro_repositories --src-dir $src_dir --github-key $GITHUB_TOKEN " +
+    //             "--recipes $recipes_yaml  --rosdistro-index $rosdistro_index --clean"
+    //           stash(name: srcStash(params.release_label), includes: "$src_dir/")
+    //         }
+    //       }
+    //     }
+    //   }
+    //   post {
+    //     always {
+    //       archiveArtifacts(artifacts: "$recipes_dir/*.yaml")
+    //     }
+    //     cleanup {
+    //       library("tailor-meta@${params.tailor_meta}")
+    //       cleanDocker()
+    //       deleteDir()
+    //     }
+    //   }
+    // }
 
 
-    stage("Create upstream mirrors") {
-      agent none
-      steps {
-        script {
-          def jobs = distributions.collectEntries { distribution ->
-            [distribution, { node {
-              try {
-                def parent_image = docker.image(parentImage(params.release_label, params.docker_registry))
-                retry(params.retries as Integer) {
-                  docker.withRegistry(params.docker_registry, docker_credentials) {
-                    parent_image.pull()
-                  }
-                }
-                parent_image.inside("-v $HOME/tailor/gpg:/gpg") {
-                  unstash(name: 'rosdistro')
+    // stage("Create upstream mirrors") {
+    //   agent none
+    //   steps {
+    //     script {
+    //       def jobs = distributions.collectEntries { distribution ->
+    //         [distribution, { node {
+    //           try {
+    //             def parent_image = docker.image(parentImage(params.release_label, params.docker_registry))
+    //             retry(params.retries as Integer) {
+    //               docker.withRegistry(params.docker_registry, docker_credentials) {
+    //                 parent_image.pull()
+    //               }
+    //             }
+    //             parent_image.inside("-v $HOME/tailor/gpg:/gpg") {
+    //               unstash(name: 'rosdistro')
 
-                  sh("mirror_upstream $upstream_yaml --version $params.timestamp --apt-repo $params.apt_repo " +
-                     "--release-label $params.release_label --distribution $distribution --keys /gpg/*.key " +
-                     "${params.force_mirror ? '--force-mirror' : ''} ${params.deploy ? '--publish' : ''}")
-                }
-              } finally {
-                  library("tailor-meta@${params.tailor_meta}")
-                  cleanDocker()
-                  try {
-                    deleteDir()
-                  } catch (e) {
-                    println e
-                  }
-              }
-            }}]
-          }
-          parallel(jobs)
-        }
-      }
-    }
+    //               sh("mirror_upstream $upstream_yaml --version $params.timestamp --apt-repo $params.apt_repo " +
+    //                  "--release-label $params.release_label --distribution $distribution --keys /gpg/*.key " +
+    //                  "${params.force_mirror ? '--force-mirror' : ''} ${params.deploy ? '--publish' : ''}")
+    //             }
+    //           } finally {
+    //               library("tailor-meta@${params.tailor_meta}")
+    //               cleanDocker()
+    //               try {
+    //                 deleteDir()
+    //               } catch (e) {
+    //                 println e
+    //               }
+    //           }
+    //         }}]
+    //       }
+    //       parallel(jobs)
+    //     }
+    //   }
+    // }
 
-    stage("Create packaging environment") {
-      agent none
-      steps {
-        script {
-          def jobs = recipes.collectEntries { recipe_label, recipe_path ->
-            [recipe_label, { node {
-              try {
-                def parent_image = docker.image(parentImage(params.release_label, params.docker_registry))
-                retry(params.retries as Integer) {
-                  docker.withRegistry(params.docker_registry, docker_credentials) { parent_image.pull() }
+    // stage("Create packaging environment") {
+    //   agent none
+    //   steps {
+    //     script {
+    //       def jobs = recipes.collectEntries { recipe_label, recipe_path ->
+    //         [recipe_label, { node {
+    //           try {
+    //             def parent_image = docker.image(parentImage(params.release_label, params.docker_registry))
+    //             retry(params.retries as Integer) {
+    //               docker.withRegistry(params.docker_registry, docker_credentials) { parent_image.pull() }
 
-                  parent_image.inside() {
-                    unstash(name: srcStash(params.release_label))
-                    unstash(name: recipeStash(recipe_label))
-                    sh "ROS_PYTHON_VERSION=$params.python_version generate_bundle_templates --src-dir $src_dir --template-dir $debian_dir --recipe $recipe_path"
-                    stash(name: debianStash(recipe_label), includes: "$debian_dir/")
-                  }
-                }
+    //               parent_image.inside() {
+    //                 unstash(name: srcStash(params.release_label))
+    //                 unstash(name: recipeStash(recipe_label))
+    //                 sh "ROS_PYTHON_VERSION=$params.python_version generate_bundle_templates --src-dir $src_dir --template-dir $debian_dir --recipe $recipe_path"
+    //                 stash(name: debianStash(recipe_label), includes: "$debian_dir/")
+    //               }
+    //             }
 
-                def bundle_image = docker.image(bundleImage(recipe_label, params.docker_registry))
-                retry(params.retries as Integer) {
-                  withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'tailor_aws']]) {
-                    bundle_image = docker.build(bundleImage(recipe_label, params.docker_registry),
-                      "-f $debian_dir/Dockerfile --no-cache " +
-                      "--build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
-                      "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY $workspace_dir")
-                  }
-                }
+    //             def bundle_image = docker.image(bundleImage(recipe_label, params.docker_registry))
+    //             retry(params.retries as Integer) {
+    //               withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'tailor_aws']]) {
+    //                 bundle_image = docker.build(bundleImage(recipe_label, params.docker_registry),
+    //                   "-f $debian_dir/Dockerfile --no-cache " +
+    //                   "--build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
+    //                   "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY $workspace_dir")
+    //               }
+    //             }
 
-                retry(params.retries as Integer) {
-                  docker.withRegistry(params.docker_registry, docker_credentials) { bundle_image.push() }
-                }
+    //             retry(params.retries as Integer) {
+    //               docker.withRegistry(params.docker_registry, docker_credentials) { bundle_image.push() }
+    //             }
 
-              } finally {
-                // Jenkins requires all artifacts to have unique filenames
-                sh "find $debian_dir -type f -exec mv {} {}-$recipe_label \\; || true"
-                archiveArtifacts(
-                  artifacts: "$debian_dir/rules*, $debian_dir/control*, $debian_dir/Dockerfile*", allowEmptyArchive: true)
-                
-                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'tailor_aws']]) {
-                  s3Upload(
-                    bucket: params.apt_repo.replace('s3://', ''),
-                    path: "${params.release_label}/dependencies",
-                    includePathPattern: 'control*',
-                    workingDir: "${debian_dir}",
-                  )
-                }
-                library("tailor-meta@${params.tailor_meta}")
-                cleanDocker()
-                try {
-                  deleteDir()
-                } catch (e) {
-                  println e
-                }
-              }
-            }}]
-          }
-          parallel(jobs)
-        }
-      }
-    }
+    //           } finally {
+    //             // Jenkins requires all artifacts to have unique filenames
+    //             sh "find $debian_dir -type f -exec mv {} {}-$recipe_label \\; || true"
+    //             archiveArtifacts(
+    //               artifacts: "$debian_dir/rules*, $debian_dir/control*, $debian_dir/Dockerfile*", allowEmptyArchive: true)
 
-    stage("Build and package") {
-      agent none
-      steps {
-        script {
-          def jobs = recipes.collectEntries { recipe_label, recipe_path ->
-            [recipe_label, { node {
-              try {
-                def bundle_image = docker.image(bundleImage(recipe_label, params.docker_registry))
-                retry(params.retries as Integer) {
-                  docker.withRegistry(params.docker_registry, docker_credentials) { bundle_image.pull() }
-                }
-                bundle_image.inside("-v $HOME/tailor/ccache:/ccache -e CCACHE_DIR=/ccache") {
-                // The cache sizes need to be consistent. 
-                // If the ccache gets larger than the Jenkins size below it will be discarded.
-                // bundle_image.inside("-v $HOME/tailor/ccache:/ccache -e CCACHE_DIR=/ccache -e CCACHE_MAXSIZE=4900M") {
-                  // // Invoke the Jenkins Job Cacher Plugin via the cache method.
-                  // // Set the max cache size to 4GB, as S3 only allows a 5GB max upload at once
-                  // cache(maxCacheSize: 4900, caches: [
-                  //  arbitraryFileCache(path: '${HOME}/tailor/ccache', cacheName: recipe_label, compressionMethod: 'TARGZ_BEST_SPEED')
-                  // ]) {
-                      unstash(name: srcStash(params.release_label))
-                      unstash(name: debianStash(recipe_label))
-                      sh("""
-                        ccache -z
-                        cd $workspace_dir && dpkg-buildpackage -uc -us -b
-                        ccache -s -v
-                      """)
-                      stash(name: packageStash(recipe_label), includes: "*.deb")
-                  // }
-                }
-              } finally {
-                // Don't archive debs - too big. Consider s3 upload?
-                // archiveArtifacts(artifacts: "*.deb", allowEmptyArchive: true)
-                library("tailor-meta@${params.tailor_meta}")
-                try {
-                  if (fileExists(".")) {
-                    deleteDir()
-                  }
-                } catch (e) {
-                  println e
-                }
-                cleanDocker()
-              }
-            }}]
-          }
-          parallel(jobs)
-        }
-      }
-    }
+    //             withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'tailor_aws']]) {
+    //               s3Upload(
+    //                 bucket: params.apt_repo.replace('s3://', ''),
+    //                 path: "${params.release_label}/dependencies",
+    //                 includePathPattern: 'control*',
+    //                 workingDir: "${debian_dir}",
+    //               )
+    //             }
+    //             library("tailor-meta@${params.tailor_meta}")
+    //             cleanDocker()
+    //             try {
+    //               deleteDir()
+    //             } catch (e) {
+    //               println e
+    //             }
+    //           }
+    //         }}]
+    //       }
+    //       parallel(jobs)
+    //     }
+    //   }
+    // }
 
-    stage("Ship packages") {
-      agent none
-      steps {
-        script {
-          def jobs = distributions.collectEntries { distribution ->
-            [distribution, { node {
-              try {
-                def parent_image = docker.image(parentImage(params.release_label, params.docker_registry))
-                retry(params.retries as Integer) {
-                  docker.withRegistry(params.docker_registry, docker_credentials) { parent_image.pull() }
-                }
+    // stage("Build and package") {
+    //   agent none
+    //   steps {
+    //     script {
+    //       def jobs = recipes.collectEntries { recipe_label, recipe_path ->
+    //         [recipe_label, { node {
+    //           try {
+    //             def bundle_image = docker.image(bundleImage(recipe_label, params.docker_registry))
+    //             retry(params.retries as Integer) {
+    //               docker.withRegistry(params.docker_registry, docker_credentials) { bundle_image.pull() }
+    //             }
+    //             bundle_image.inside("-v $HOME/tailor/ccache:/ccache -e CCACHE_DIR=/ccache") {
+    //             // The cache sizes need to be consistent.
+    //             // If the ccache gets larger than the Jenkins size below it will be discarded.
+    //             // bundle_image.inside("-v $HOME/tailor/ccache:/ccache -e CCACHE_DIR=/ccache -e CCACHE_MAXSIZE=4900M") {
+    //               // // Invoke the Jenkins Job Cacher Plugin via the cache method.
+    //               // // Set the max cache size to 4GB, as S3 only allows a 5GB max upload at once
+    //               // cache(maxCacheSize: 4900, caches: [
+    //               //  arbitraryFileCache(path: '${HOME}/tailor/ccache', cacheName: recipe_label, compressionMethod: 'TARGZ_BEST_SPEED')
+    //               // ]) {
+    //                   unstash(name: srcStash(params.release_label))
+    //                   unstash(name: debianStash(recipe_label))
+    //                   sh("""
+    //                     ccache -z
+    //                     cd $workspace_dir && dpkg-buildpackage -uc -us -b
+    //                     ccache -s -v
+    //                   """)
+    //                   stash(name: packageStash(recipe_label), includes: "*.deb")
+    //               // }
+    //             }
+    //           } finally {
+    //             // Don't archive debs - too big. Consider s3 upload?
+    //             // archiveArtifacts(artifacts: "*.deb", allowEmptyArchive: true)
+    //             library("tailor-meta@${params.tailor_meta}")
+    //             try {
+    //               if (fileExists(".")) {
+    //                 deleteDir()
+    //               }
+    //             } catch (e) {
+    //               println e
+    //             }
+    //             cleanDocker()
+    //           }
+    //         }}]
+    //       }
+    //       parallel(jobs)
+    //     }
+    //   }
+    // }
 
-                parent_image.inside("-v $HOME/tailor/gpg:/gpg") {
-                  recipes.each { recipe_label, recipe_path ->
-                    if (recipe_label.contains(distribution)) {
-                      unstash(name: packageStash(recipe_label))
-                    }
-                  }
-                  unstash(name: 'rosdistro')
-                  if (params.deploy) {
-                    sh("publish_packages *.deb --release-label $params.release_label --apt-repo $params.apt_repo " +
-                        "--keys /gpg/*.key --distribution $distribution " +
-                        "${params.days_to_keep ? '--days-to-keep ' + params.days_to_keep : ''} " +
-                        "${params.num_to_keep ? '--num-to-keep ' + params.num_to_keep : ''}")
-                  }
-                }
-              } finally {
-                library("tailor-meta@${params.tailor_meta}")
-                cleanDocker()
-                try {
-                  deleteDir()
-                } catch (e) {
-                  println e
-                }
-              }
-            }}]
-          }
-          parallel(jobs)
-        }
-      }
-    }
+    // stage("Ship packages") {
+    //   agent none
+    //   steps {
+    //     script {
+    //       def jobs = distributions.collectEntries { distribution ->
+    //         [distribution, { node {
+    //           try {
+    //             def parent_image = docker.image(parentImage(params.release_label, params.docker_registry))
+    //             retry(params.retries as Integer) {
+    //               docker.withRegistry(params.docker_registry, docker_credentials) { parent_image.pull() }
+    //             }
+
+    //             parent_image.inside("-v $HOME/tailor/gpg:/gpg") {
+    //               recipes.each { recipe_label, recipe_path ->
+    //                 if (recipe_label.contains(distribution)) {
+    //                   unstash(name: packageStash(recipe_label))
+    //                 }
+    //               }
+    //               unstash(name: 'rosdistro')
+    //               if (params.deploy) {
+    //                 sh("publish_packages *.deb --release-label $params.release_label --apt-repo $params.apt_repo " +
+    //                     "--keys /gpg/*.key --distribution $distribution " +
+    //                     "${params.days_to_keep ? '--days-to-keep ' + params.days_to_keep : ''} " +
+    //                     "${params.num_to_keep ? '--num-to-keep ' + params.num_to_keep : ''}")
+    //               }
+    //             }
+    //           } finally {
+    //             library("tailor-meta@${params.tailor_meta}")
+    //             cleanDocker()
+    //             try {
+    //               deleteDir()
+    //             } catch (e) {
+    //               println e
+    //             }
+    //           }
+    //         }}]
+    //       }
+    //       parallel(jobs)
+    //     }
+    //   }
+    // }
 
     stage("Invalidate CDN's cache") {
       agent any

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,6 +40,7 @@ pipeline {
     booleanParam(name: 'deploy', defaultValue: false)
     booleanParam(name: 'force_mirror', defaultValue: false)
     booleanParam(name: 'invalidate_cache', defaultValue: false)
+    string(name: 'apt_refresh_key')
   }
 
   options {
@@ -81,7 +82,6 @@ pipeline {
           dir('tailor-distro') {
             checkout(scm)
           }
-          def APT_REFRESH_KEY = sh(script: "date -u +%G-W%V", returnStdout: true, label: 'Get week number').trim()
           def parent_image_label = parentImage(params.release_label, params.docker_registry)
           def parent_image = docker.image(parent_image_label)
           try {
@@ -105,7 +105,7 @@ pipeline {
                 "--build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
                 "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY " +
                 "--build-arg BUILDKIT_INLINE_CACHE=1 " +
-                "--build-arg APT_REFRESH_KEY=${APT_REFRESH_KEY} .")
+                "--build-arg APT_REFRESH_KEY=${params.apt_refresh_key} .")
             }
             parent_image.inside() {
               sh('pip3 install -e tailor-distro --break-system-packages')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,7 +100,8 @@ pipeline {
               parent_image = docker.build(parent_image_label,
                 "-f tailor-distro/environment/Dockerfile --cache-from ${parent_image_label} " +
                 "--build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
-                "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY .")
+                "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY " +
+                "--build-arg BUILDKIT_INLINE_CACHE=1 .")
             }
             parent_image.inside() {
               sh('pip3 install -e tailor-distro --break-system-packages')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,7 @@ pipeline {
           dir('tailor-distro') {
             checkout(scm)
           }
-          def APT_REFRESH_KEY = sh(script: "date -u +%G-W%V", returnStdout: true).trim()
+          def APT_REFRESH_KEY = sh(script: "date -u +%G-W%V", returnStdout: true, label: 'Get week number').trim()
           def parent_image_label = parentImage(params.release_label, params.docker_registry)
           def parent_image = docker.image(parent_image_label)
           try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -235,8 +235,8 @@ pipeline {
                 retry(params.retries as Integer) {
                   withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'tailor_aws']]) {
                     bundle_image = docker.build(bundle_image_label,
-                      "${params.invalidate_cache ? '--no-cache ' : ''}" +
-                      "-f $debian_dir/Dockerfile --cache-from ${bundle_image_label}" +
+                      "${params.invalidate_cache ? '--no-cache ' : ''} " +
+                      "-f $debian_dir/Dockerfile --cache-from ${bundle_image_label} " +
                       "--build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
                       "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY $workspace_dir " +
                       "--build-arg BUILDKIT_INLINE_CACHE=1 " +

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -238,9 +238,9 @@ pipeline {
                       "${params.invalidate_cache ? '--no-cache ' : ''} " +
                       "-f $debian_dir/Dockerfile --cache-from ${bundle_image_label} " +
                       "--build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
-                      "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY $workspace_dir " +
+                      "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY " +
                       "--build-arg BUILDKIT_INLINE_CACHE=1 " +
-                      "--build-arg APT_REFRESH_KEY=${params.apt_refresh_key} .")
+                      "--build-arg APT_REFRESH_KEY=${params.apt_refresh_key} $workspace_dir")
                   }
                 }
 

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -13,7 +13,10 @@ ENV AWS_SECRET_ACCESS_KEY ${AWS_SECRET_ACCESS_KEY}
 ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONUNBUFFERED 1
 
+ARG APT_REFRESH_KEY
+
 RUN sed -i 's/archive.ubuntu.com/us-east-1.ec2.&/g' /etc/apt/sources.list
+RUN echo "APT refresh key=${APT_REFRESH_KEY}"
 RUN apt-get update && apt-get install --no-install-recommends -y locales curl gnupg1 sudo
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8

--- a/tailor_distro/debian_templates/Dockerfile.j2
+++ b/tailor_distro/debian_templates/Dockerfile.j2
@@ -12,7 +12,9 @@ ENV AWS_SECRET_ACCESS_KEY ${AWS_SECRET_ACCESS_KEY}
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV PYTHONUNBUFFERED 1
+ARG APT_REFRESH_KEY
 
+RUN echo "APT refresh key=${APT_REFRESH_KEY}"
 RUN sed -i 's/archive.ubuntu.com/us-east-1.ec2.&/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install --no-install-recommends -y \
     locales curl gnupg sudo ccache software-properties-common expect vim


### PR DESCRIPTION
The current flag --cache-from given to the docker build command is not working. If we want to re-use previous docker images that we already have build when no change is made inside the dockerfile, then this PR makes that happen. When using the cache with Dockers, we need a balance between speed and working with stale apt packages. Thus, this PR tries to prevent having very old packages by invalidating the cache once a week. Moreover, it exposes a new parameter to invalidate the cache manually if required.

This PR does the following: 
* makes use of Docker cache when re-building the Docker images (**Note**: this is used both for the parent image as for the bundle images)
* exposes a new parameter named `invalidate_cache` to manually trigger the cache invalidation when needed
* uses a parameter named `apt_refresh_key` which is set to a combination of year and week number to trigger the cache invalidation once per week. This way the apt packages get updated at least once per week and we do not risk missing important updates. 