### PR TITLE
Explicitly set ROS_VERSION in rules template

### DIFF
--- a/tailor_distro/debian_templates/rules.j2
+++ b/tailor_distro/debian_templates/rules.j2
@@ -38,10 +38,13 @@ override_dh_auto_build:
 	env && \
 	if [ "{{ distro_name }}" = "ros1" ]; then \
   		FORCE_PKG_REBUILD="$(FORCE_PKG_REBUILD_ROS1)"; \
+		TARGET_ROS_VERSION=1; \
 	elif [ "{{ distro_name }}" = "ros2" ]; then \
   		FORCE_PKG_REBUILD="$(FORCE_PKG_REBUILD_ROS2)"; \
+		TARGET_ROS_VERSION=2; \
 	else \
   		FORCE_PKG_REBUILD=""; \
+		TARGET_ROS_VERSION=""; \
 	fi; \
 	if [ -n "$$FORCE_PKG_REBUILD" ]; then \
 	  echo "Requested force-rebuild: $$FORCE_PKG_REBUILD"; \
@@ -62,6 +65,7 @@ override_dh_auto_build:
 			source $(INSTALL_DIR)/{{ underlay_name }}/setup.bash && \
 		{% endif %}
 	{% endfor %}
+	export ROS_VERSION=$$TARGET_ROS_VERSION; \
 	TERM=dumb colcon build \
 		--parallel-workers 8 \
 		--packages-skip-cache-valid \


### PR DESCRIPTION
Sourcing the ROS1 underlay prior to building ROS2 causes the ROS_VERSION env var to get set to "1" which then causes unintended and missing build artifacts to be generated because colcon uses catkin vs ament to build the ROS2 packages.

Set ROS_VERSION explicitly _after_ sourcing the underlay so all ROS2 packages build correctly that rely on ROS_VERSION.