### PR TITLE
Install rustup system-wide

### DIFF
--- a/tailor_distro/debian_templates/Dockerfile.j2
+++ b/tailor_distro/debian_templates/Dockerfile.j2
@@ -55,7 +55,7 @@ ENV RUSTUP_HOME=/opt/rust/rustup \
     PATH=/opt/rust/cargo/bin:${PATH}
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
       | sh -s -- -y --no-modify-path --profile minimal \
-        --default-toolchain "${RUST_TOOLCHAIN_VERSION}" && \
+        --default-toolchain stable && \
     chmod -R a+rwX /opt/rust && \
     cargo --version
 

--- a/tailor_distro/debian_templates/Dockerfile.j2
+++ b/tailor_distro/debian_templates/Dockerfile.j2
@@ -46,10 +46,7 @@ RUN if [[ -f /etc/apt/sources.list.d/ubuntu.sources ]]; then \
     ccache --set-config=cache_dir=/ccache && \
     rm -rf /var/lib/apt/lists/*
 
-# Install rustup system-wide and pin a modern toolchain. This shadows the apt
-# 'cargo' that rosdep installs (via <build_depend>cargo</build_depend>), which is
-# too old to parse newer crates'
-ARG RUST_TOOLCHAIN_VERSION=1.93.0
+# Install rustup system-wide using latest stable toolchain
 ENV RUSTUP_HOME=/opt/rust/rustup \
     CARGO_HOME=/opt/rust/cargo \
     PATH=/opt/rust/cargo/bin:${PATH}

--- a/tailor_distro/debian_templates/Dockerfile.j2
+++ b/tailor_distro/debian_templates/Dockerfile.j2
@@ -46,6 +46,19 @@ RUN if [[ -f /etc/apt/sources.list.d/ubuntu.sources ]]; then \
     ccache --set-config=cache_dir=/ccache && \
     rm -rf /var/lib/apt/lists/*
 
+# Install rustup system-wide and pin a modern toolchain. This shadows the apt
+# 'cargo' that rosdep installs (via <build_depend>cargo</build_depend>), which is
+# too old to parse newer crates'
+ARG RUST_TOOLCHAIN_VERSION=1.93.0
+ENV RUSTUP_HOME=/opt/rust/rustup \
+    CARGO_HOME=/opt/rust/cargo \
+    PATH=/opt/rust/cargo/bin:${PATH}
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+      | sh -s -- -y --no-modify-path --profile minimal \
+        --default-toolchain "${RUST_TOOLCHAIN_VERSION}" && \
+    chmod -R a+rwX /opt/rust && \
+    cargo --version
+
 # Create auth config file for accesing s3 via apt
 RUN echo "AccessKeyId = $AWS_ACCESS_KEY_ID" | tee /etc/apt/s3auth.conf && \
     echo "SecretAccessKey = $AWS_SECRET_ACCESS_KEY" | tee -a /etc/apt/s3auth.conf && \

--- a/tailor_distro/debian_templates/Dockerfile.j2
+++ b/tailor_distro/debian_templates/Dockerfile.j2
@@ -46,13 +46,20 @@ RUN if [[ -f /etc/apt/sources.list.d/ubuntu.sources ]]; then \
     ccache --set-config=cache_dir=/ccache && \
     rm -rf /var/lib/apt/lists/*
 
-# Install rustup system-wide using latest stable toolchain
+# Install rustup system-wide using a pinned installer (with SHA256 verification).
+ARG RUSTUP_VERSION=1.29.0
+ARG RUSTUP_SHA256=4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10
 ENV RUSTUP_HOME=/opt/rust/rustup \
     CARGO_HOME=/opt/rust/cargo \
     PATH=/opt/rust/cargo/bin:${PATH}
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-      | sh -s -- -y --no-modify-path --profile minimal \
-        --default-toolchain stable && \
+RUN curl --proto '=https' --tlsv1.2 -sSfL \
+      "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init" \
+      -o /tmp/rustup-init && \
+    echo "${RUSTUP_SHA256}  /tmp/rustup-init" | sha256sum --check && \
+    chmod +x /tmp/rustup-init && \
+    /tmp/rustup-init -y --no-modify-path --profile minimal \
+      --default-toolchain stable && \
+    rm /tmp/rustup-init && \
     chmod -R a+rwX /opt/rust && \
     cargo --version
 


### PR DESCRIPTION
Install rustup system-wide to use the latest stable toolchain and enable the use of latest cargo.